### PR TITLE
Fix 'is_valid_mac' to include mcast mac address

### DIFF
--- a/lldp/l2_packet_linux.c
+++ b/lldp/l2_packet_linux.c
@@ -60,7 +60,7 @@ struct l2_packet_data {
 
 int l2_packet_get_own_src_addr(struct l2_packet_data *l2, u8 *addr)
 {
-	if (is_san_mac(l2->san_mac_addr))
+	if (is_valid_mac(l2->san_mac_addr))
 		memcpy(addr, l2->san_mac_addr, ETH_ALEN);
 	else {
 		/* get an appropriate src MAC to use if the port is


### PR DESCRIPTION
The function now checks for 1) all 0s mac, 2) all Fs mac, 3) IANA
multicast mac and 4) IANA ipv6 multicast address. Function 'is_san_mac'
has been replaced by 'is_valid_mac'.

Following IANA document talks about multicast address:
*https://www.iana.org/assignments/ethernet-numbers/ethernet-numbers.xhtml

" IANA allocates addresses under the IANA OUI (00-00-5E) as explained in
  [RFC7042]. Unicast addresses under the IANA OUI start
  with 00-00-5E, while multicast addresses under the IANA OUI start with
  01-00-5E. In the lists below, these initial 3 bytes are omitted for
  brevity. As described in [RFC7042], 48-bit MAC addresses
  in the range 33-33-00-00-00-00 to 33-33-FF-FF-FF-FF are used for
  IPv6 multicast."