### PR TITLE
Use interface index instead of name in libconfig

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -111,4 +111,7 @@ void destroy_cfg(void);
 int check_cfg_file(void);
 int check_for_old_file_format(void);
 void init_ports(void);
+
+void config_ifkey(const char *name, char *ifkey);
+
 #endif /* _CONFIG_H_ */

--- a/lldp_dcbx_cfg.c
+++ b/lldp_dcbx_cfg.c
@@ -99,12 +99,15 @@ static config_setting_t *construct_new_setting(char *device_name)
 	config_setting_t *tmp2_setting = NULL;
 	char abuf[32];
 	int i;
+	char device_name_sanitized[IFNAMSIZ];
 
 	dcbx_setting = config_lookup(&lldpad_cfg, DCBX_SETTING);
 	if (!dcbx_setting)
 		return NULL;
 
-	eth_setting = config_setting_add(dcbx_setting, device_name,
+	config_ifkey(device_name, device_name_sanitized);
+
+	eth_setting = config_setting_add(dcbx_setting, device_name_sanitized,
 		CONFIG_TYPE_GROUP);
 	if (!eth_setting)
 		goto set_error;
@@ -371,11 +374,13 @@ static int _set_persistent(char *device_name, int dcb_enable,
 	config_setting_t *setting_value = NULL;
 	char abuf[2*DCB_MAX_TLV_LENGTH + 1];
 	int result, i;
+	char device_name_sanitized[IFNAMSIZ];
 
 	dcbx_setting = config_lookup(&lldpad_cfg, DCBX_SETTING);
+	config_ifkey(device_name, device_name_sanitized);
 	if (dcbx_setting)
 		eth_settings = config_setting_get_member(dcbx_setting,
-							 device_name);
+							 device_name_sanitized);
 
 	/* init the internal data store for device_name */
 	if (NULL == eth_settings) {
@@ -782,13 +787,15 @@ int get_persistent(char *device_name, full_dcb_attribs *attribs)
 	int result = cmd_failed, i;
 	int results[MAX_USER_PRIORITIES];
 	int len;
-	char abuf[32];
+	char abuf[32], device_name_sanitized[IFNAMSIZ];
 
 	memset(attribs, 0, sizeof(*attribs));
 	dcbx_setting = config_lookup(&lldpad_cfg, DCBX_SETTING);
+
+	config_ifkey(device_name, device_name_sanitized);
 	if (dcbx_setting)
-		eth_settings = config_setting_get_member(dcbx_setting,
-							 device_name);
+		eth_settings = config_setting_get_member(dcbx_setting, 
+							 device_name_sanitized);
 
 	/* init the internal data store for device_name */
 	result = get_default_persistent(device_name, attribs);
@@ -1071,13 +1078,16 @@ int get_dcb_enable_state(char *ifname, int *result)
 	int rc = EINVAL;
 	config_setting_t *settings = NULL;
 	char path[sizeof(DCBX_SETTING) + IFNAMSIZ + 16];
+	char ifkey[IFNAMSIZ];
+
+	config_ifkey(ifname, ifkey);
 
 	memset(path, 0, sizeof(path));
-	snprintf(path, sizeof(path), "%s.%s.dcb_enable", DCBX_SETTING, ifname);
+	snprintf(path, sizeof(path), "%s.%s.dcb_enable", DCBX_SETTING, ifkey); 
 	settings = config_lookup(&lldpad_cfg, path);
 	if (!settings) {
 		LLDPAD_INFO("### %s:%s:failed on %s\n", __func__, ifname, path);
-		snprintf(path, sizeof(path), "%s.dcb_enable", ifname);
+		snprintf(path, sizeof(path), "%s.dcb_enable", ifkey); 
 		settings = config_lookup(&lldpad_cfg, path);
 		if (!settings) {
 			LLDPAD_INFO("### %s:%s:failed again %s\n", __func__, ifname, path);


### PR DESCRIPTION
This patch allows lldpad to use any network interface name.

Right now lldpad does not accept interface names containing non
alphanumeric characters (except '_' and '-'). As Markus Mehlan reported
(http://lists.open-lldp.org/pipermail/lldp-devel/2017-March/001251.html)
this is a constraint originally from libconfig.

Libconfig manual states that:
*http://www.hyperrealm.com/libconfig/libconfig_manual.html

"All names are case-sensitive. They may consist only of
alphanumeric characters, dashes (‘-’), underscores (‘_’), and
asterisks (‘*’), and must begin with aletter or asterisk. No
other characters are allowed."

Given this restriction we thought the best idea would be to interact
with libconfig using a "sanitized" version of the interface name. The
names in this patch are generated using the index of the interface as
returned by if_nametoindex() function. The name string has the format
"ifX" where X is the interface index.