### PR TITLE
memleak on received TLVs from modules

### DIFF
--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -1924,7 +1924,7 @@ int ieee8021qaz_rchange(struct port *port, struct lldp_agent *agent,
 	struct ieee8021qaz_unpkd_tlvs *rx;
 
 	if (agent->type != NEAREST_BRIDGE)
-		return 0;
+		return SUBTYPE_INVALID;
 
 	qaz_tlvs = ieee8021qaz_data(port->ifname);
 	if (!qaz_tlvs)
@@ -2005,7 +2005,7 @@ int ieee8021qaz_rchange(struct port *port, struct lldp_agent *agent,
 		}
 	}
 
-	return TLV_OK;
+	return SUBTYPE_INVALID;
 }
 
 static void ieee8021qaz_free_rx(struct ieee8021qaz_unpkd_tlvs *rx)

--- a/lldp_evb.c
+++ b/lldp_evb.c
@@ -210,7 +210,8 @@ static int evb_rchange(struct port *port, struct lldp_agent *agent,
 	u8 oui_subtype[OUI_SUB_SIZE] = LLDP_OUI_SUBTYPE;
 
 	if (agent->type != NEAREST_CUSTOMER_BRIDGE)
-		return 0;
+		return SUBTYPE_INVALID;
+
 	ed = evb_data(port->ifname, agent->type);
 
 	if (!ed)
@@ -229,7 +230,7 @@ static int evb_rchange(struct port *port, struct lldp_agent *agent,
 		if (!ed->txmit) {
 			LLDPAD_WARN("%s:%s agent %d EVB Config disabled\n",
 				__func__, ed->ifname, agent->type);
-			return TLV_OK;
+			return SUBTYPE_INVALID;
 		}
 
 		LLDPAD_DBG("%s:%s agent %d received tlv:\n", __func__,
@@ -246,7 +247,8 @@ static int evb_rchange(struct port *port, struct lldp_agent *agent,
 		evb_print_tlvinfo(ed->ifname, &ed->tie);
 		vdp_update(port->ifname, ed->tie.ccap);
 	}
-	return TLV_OK;
+
+	return SUBTYPE_INVALID;
 }
 
 /*

--- a/lldp_evb22.c
+++ b/lldp_evb22.c
@@ -305,7 +305,8 @@ static int evb22_rchange(struct port *port, struct lldp_agent *agent,
 	u8 oui_subtype[OUI_SUB_SIZE] = LLDP_MOD_EVB22_OUI;
 
 	if (agent->type != NEAREST_CUSTOMER_BRIDGE)
-		return 0;
+		return SUBTYPE_INVALID;
+
 	ed = evb22_data(port->ifname, agent->type);
 
 	if (!ed)
@@ -324,7 +325,7 @@ static int evb22_rchange(struct port *port, struct lldp_agent *agent,
 		if (!ed->txmit) {
 			LLDPAD_WARN("%s:%s agent %d EVB Config disabled\n",
 				__func__, ed->ifname, agent->type);
-			return TLV_OK;
+			return SUBTYPE_INVALID;
 		}
 
 		LLDPAD_DBG("%s:%s agent %d received tlv:\n", __func__,
@@ -341,7 +342,8 @@ static int evb22_rchange(struct port *port, struct lldp_agent *agent,
 		evb22_print_tlvinfo(ed->ifname, &ed->out);
 		/* TODO vdp_update(port->ifname, ed->tie.ccap); */
 	}
-	return TLV_OK;
+
+	return SUBTYPE_INVALID;
 }
 
 /*


### PR DESCRIPTION
Most of the TLV modules that have an rchange handler for received TLVs
seem to get the return values wrong, returning 0 or TLV_OK without
freeing or storing the unpacked TLV to be freed later. That leaks the
allocation, as rxProcessFrame believes the module has claimed ownership.

In a test setup, it's probably easiest to see by enabling some TLV type
on one side of a connection only.  Or, any unexpected TLV that doesn't
get handled will be erroneously leaked by the EVB modules.