### PR TITLE
DCB set state operation return value check

### DIFF
--- a/lldp_dcbx_cmds.c
+++ b/lldp_dcbx_cmds.c
@@ -259,8 +259,12 @@ static cmd_status set_dcb_state(char *port_id, char *ibuf, int ilen)
 
 	if (ilen == (off + CFG_DCB_DLEN)) {
 		state = (*(ibuf+off+DCB_STATE)) ^ '0';
-		set_hw_state(port_id, state);
-		rval = save_dcb_enable_state(port_id, state);
+
+		if(set_hw_state(port_id, state) < 0) {
+		    rval = cmd_not_capable;
+		} else {
+		    rval = save_dcb_enable_state(port_id, state);
+		}
 	} else {
 		printf("error - setcommand has invalid argument length\n");
 		rval = cmd_bad_params;


### PR DESCRIPTION
Added a return value check for 'set_dcb_state'. The function
didn't check whether the 'set_hw_state' was successful.
Without this check 'dcb sc <if> dcb [on/off]' returns 'Successful'
even when operation is not supported in driver.

Fixes: 527ac435e46c ("lldpad: Do not enable CEE mode if explicitly disabled")
Signed-off-by: Shay Agroskin <shayag@mellanox.com>