### PR TITLE
ecp22: deinit l2_packet_data before freeing ecp22

### DIFF
--- a/qbg/ecp22.c
+++ b/qbg/ecp22.c
@@ -816,6 +816,7 @@ static void ecp22_remove(struct ecp22 *ecp)
 	ecp22_removelist(&ecp->isfree.head);
 	ecp->isfree.freecnt = 0;
 	LIST_REMOVE(ecp, node);
+	l2_packet_deinit(ecp->l2);
 	free(ecp);
 }
 


### PR DESCRIPTION
When a link is shut, an ecp22 and l2_packet_data structure is removed for
the corresponding interface. l2_packet_data has a socket that needs to be
closed via l2_packet_deinit before the ecp22 structure can be freed.

Failure to close the socket causes a segfault once lldpad has exceeded the
maximum open file descriptors.