### PR TITLE
OID Printing changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,9 +86,11 @@ vdptool_LDADD = liblldp_clif.la
 vdptool_LDFLAGS = -llldp_clif $(LIBNL_LIBS)
 
 dcbtool_SOURCES = dcbtool.c dcbtool_cmds.c parse_cli.l \
-weak_readline.c $(lldpad_include_HEADERS) $(noinst_HEADERS)
+	weak_readline.c lldp_rtnl.c lldp_util.c \
+	$(lldpad_include_HEADERS) $(noinst_HEADERS)
+
 dcbtool_LDADD = liblldp_clif.la
-dcbtool_LDFLAGS = -ldl -llldp_clif
+dcbtool_LDFLAGS = -ldl -llldp_clif $(LIBNL_LIBS)
 
 lldptool_SOURCES = lldptool.c lldptool_cmds.c lldp_rtnl.c \
 		   lldp_mand_clif.c lldp_basman_clif.c lldp_med_clif.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,9 @@
 # target programs to be installed in ${sbindir}
 sbin_PROGRAMS = lldpad dcbtool lldptool vdptool
 
+check_PROGRAMS = lldp_clif_test
+TESTS = $(check_PROGRAMS)
+
 # package nltest and vdptest, but do not install it anywhere
 if BUILD_DEBUG
 noinst_PROGRAMS = nltest vdptest qbg22sim
@@ -142,3 +145,7 @@ bashcompletiondir = $(sysconfdir)/bash_completion.d
 dist_bashcompletion_DATA = contrib/bash_completion/lldpad contrib/bash_completion/lldptool
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --enable-debug
+
+lldp_clif_test_SOURCES = test/lldp_clif_test.c lldp_basman_clif.c lldp_util.c \
+	lldp_rtnl.c
+lldp_clif_test_LDFLAGS = -lrt $(LIBNL_LIBS)

--- a/README
+++ b/README
@@ -186,7 +186,9 @@ lldpad Application Install
    lldpad will create the lldpad.conf file if it does not exist.
 
    For development purposes, 'lldpad' can be run directly from the build 
-   directory.
+   directory.  To run the unit tests associated with openlldpd, execute:
+
+     ./bootstrap.sh; ./configure; make check
 
 Options
 -------

--- a/dcbtool_cmds.c
+++ b/dcbtool_cmds.c
@@ -38,7 +38,6 @@
 
 static char *print_status(cmd_status status);
 static char *get_pgdesc_args(int cmd);
-static int hex2int(char *b);
 static void free_cmd_args(char *args);
 static char *get_dcb_args(void);
 static char *get_dcbx_args(void);
@@ -91,28 +90,6 @@ static char *print_status(cmd_status status)
 		break;
 	}
 	return str;
-}
-
-/* assumes input is pointer to two hex digits */
-/* returns -1 on error */
-static int hex2int(char *b)
-{
-	int i;
-	int n=0;
-	int m;
-	
-	for (i=0,m=1; i<2; i++,m--) {
-		if (isxdigit(*(b+i))) {
-			if (*(b+i) <= '9')
-				n |= (*(b+i) & 0x0f) << (4*m);
-			else
-				n |= ((*(b+i) & 0x0f) + 9) << (4*m);
-		}
-		else {
-			return -1;
-		}
-	}
-	return n;
 }
 
 static char *get_dcb_args(void)

--- a/include/lldp_util.h
+++ b/include/lldp_util.h
@@ -119,6 +119,7 @@
 
 int hexstr2bin(const char *hex, u8 *buf, size_t len);
 int bin2hexstr(const u8 *hex, size_t hexlen, char *buf, size_t buflen);
+int hex2int(char *b);
 
 int is_valid_lldp_device(const char *ifname);
 int is_active(const char *ifname);

--- a/include/lldptool.h
+++ b/include/lldptool.h
@@ -31,7 +31,6 @@
 
 struct lldp_head lldp_cli_head;
 
-int hex2int(char *b);
 int clif_command(struct clif *clif, char *cmd, int raw);
 void print_raw_message(char *msg, int print);
 int parse_print_message(char *msg, int print);

--- a/lldp_basman_clif.c
+++ b/lldp_basman_clif.c
@@ -272,8 +272,15 @@ void print_mng_addr(u16 len, char *info)
 		memset(buf, 0, sizeof(buf));
 		if (hexstr2bin(info+offset, (u8 *)&buf, oidlen))
 			printf("\tOID: Error parsing OID\n");
-		else
-			printf("\tOID: %s\n", buf);
+		else {
+			printf("\tOID: 0.");
+			for (i = 0; i < oidlen; ++i) {
+				printf("%d", buf[i]);
+				if (i != (oidlen - 1))
+					printf(".");
+			}
+			printf("\n");
+		}
 	} else if (oidlen > 128) {
 		printf("\tOID: Invalid length = %d\n", oidlen);
 	}
@@ -310,3 +317,10 @@ u32 basman_lookup_tlv_name(char *tlvid_str)
 	}
 	return INVALID_TLVID;
 }
+
+/* Local Variables:    */
+/* c-indent-level: 8   */
+/* c-basic-offset: 8   */
+/* tab-width: 8        */
+/* indent-tabs-mode: t */
+/* End:                */

--- a/lldp_util.c
+++ b/lldp_util.c
@@ -24,6 +24,7 @@
 
 *******************************************************************************/
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -120,6 +121,28 @@ int hexstr2bin(const char *hex, u8 *buf, size_t len)
 		ipos += 2;
 	}
 	return 0;
+}
+
+/* assumes input is pointer to two hex digits */
+/* returns -1 on error */
+int hex2int(char *b)
+{
+	int i;
+	int n=0;
+	int m;
+
+	for (i=0,m=1; i<2; i++,m--) {
+		if (isxdigit(*(b+i))) {
+			if (*(b+i) <= '9')
+				n |= (*(b+i) & 0x0f) << (4*m);
+			else
+				n |= ((*(b+i) & 0x0f) + 9) << (4*m);
+		}
+		else {
+			return -1;
+		}
+	}
+	return n;
 }
 
 char *print_mac(char *mac, char *buf)

--- a/lldptool.c
+++ b/lldptool.c
@@ -222,28 +222,6 @@ static void usage(void)
 		commands_usage, commands_options, commands_help);
 }
 
-/* assumes input is pointer to two hex digits */
-/* returns -1 on error */
-int hex2int(char *b)
-{
-	int i;
-	int n=0;
-	int m;
-
-	for (i=0,m=1; i<2; i++,m--) {
-		if (isxdigit(*(b+i))) {
-			if (*(b+i) <= '9')
-				n |= (*(b+i) & 0x0f) << (4*m);
-			else
-				n |= ((*(b+i) & 0x0f) + 9) << (4*m);
-		}
-		else {
-			return -1;
-		}
-	}
-	return n;
-}
-
 void print_raw_message(char *msg, int print)
 {
 	if (!print || !(print & SHOW_RAW))

--- a/test/lldp_clif_test.c
+++ b/test/lldp_clif_test.c
@@ -1,0 +1,140 @@
+/*******************************************************************************
+  SPDX-Identifier: GPL-2.0-or-later
+
+  LLDP Agent Daemon (LLDPAD) Software - clif unit tests
+  Copyright (C) 2018, Red Hat, Inc.
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms and conditions of the GNU General Public License,
+  version 2, as published by the Free Software Foundation.
+
+  This program is distributed in the hope it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+  more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+
+  The full GNU General Public License is included in this distribution in
+  the file called "COPYING".
+
+  Contact Information:
+  open-lldp Mailing List <lldp-devel@open-lldp.org>
+
+*******************************************************************************/
+
+#include "lldp.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* functions to test */
+extern void print_mng_addr(u16 len, char *info);
+
+/* tests for output functions */
+static int hook_fd = -1;
+static FILE *stdout_hook;
+static char *test_name;
+
+static void hook_stdout(char *test_id)
+{
+	if (!test_id)
+		test_name = "test_tmp.txt";
+
+	if (hook_fd == -1) {
+		hook_fd = dup(STDOUT_FILENO);
+		stdout_hook = freopen(test_id, "w", stdout);
+		test_name = strdup(test_id);
+
+		if (!stdout_hook || !test_name) {
+			fprintf(stderr, "Fatal error: unable to hook stdout\n");
+			exit(1);
+		}
+	}
+}
+
+static void unhook_stdout()
+{
+	if (hook_fd != -1) {
+		dup2(hook_fd, STDOUT_FILENO);
+		stdout = fdopen(STDOUT_FILENO, "w");
+		close(hook_fd);
+		hook_fd = -1;
+
+		unlink(test_name);
+		free(test_name);
+		test_name = NULL;
+	}
+}
+
+static int test_mgmt_printing()
+{
+	char *mgmt_info_test;
+	int result = 1;
+	FILE *output;
+	int ctr = 0;
+
+	mgmt_info_test =
+		"05010a2ff8f9" /* addrlen + subtype + addr */
+		"0100000000" /* if-subtype + ifnum */
+		"0c0103060102011f0101010100"; /* oid-len + oid */
+
+	/* start by hooking the stdout filedescriptor */
+	hook_stdout("test_mgmt_printing.txt");
+
+	print_mng_addr(strlen(mgmt_info_test), mgmt_info_test);
+
+	fflush(stdout);
+
+	output = fopen("test_mgmt_printing.txt", "r");
+	if (!output)
+		goto done;
+
+	while (!feof(output) && ctr != 3) {
+		char buf[1024];
+		if (!fgets(buf, sizeof(buf), output))
+			goto done;
+
+		if (!strcmp(buf, "IPv4: 10.47.248.249\n"))
+			ctr++;
+		else if (!strcmp(buf, "\tUnknown interface subtype: 0\n"))
+			ctr++;
+		else if (!strcmp(buf, "\tOID: 0.1.3.6.1.2.1.31.1.1.1.1.0\n"))
+			ctr++;
+		else {
+			fprintf(stderr, "FATAL: unknown line '%s'\n", buf);
+			goto done;
+		}
+	}
+	result = 0;
+
+done:
+	if (output)
+		fclose(output);
+
+	unhook_stdout();
+	return result;
+}
+
+int main(void)
+{
+	int error_counter = 0;
+
+	error_counter += test_mgmt_printing();
+
+	return error_counter ? -1 : 0;
+}
+
+/* Local Variables:    */
+/* c-indent-level: 8   */
+/* c-basic-offset: 8   */
+/* tab-width: 8        */
+/* indent-tabs-mode: t */
+/* End:                */


### PR DESCRIPTION
The OID display from lldp-tool is currently dumping the raw bytes from the MIB, rather
than formatting them into a common dotted notation.  This series corrects that by displaying
as the common notation.

Additionally, this series incorporates the GNU Autotools 'make check' facility.  It introduces a check
in 2/3 which fails, and then fixes the failure in 3/3.

Signed-off-by: Aaron Conole <aconole@redhat.com>

