### PR TITLE
Fix gcc <v7.1 Wimplicit-fallthrough error

### DIFF
--- a/lldp_mand.c
+++ b/lldp_mand.c
@@ -216,8 +216,7 @@ static int mand_bld_chassis_tlv(struct mand_data *md, struct lldp_agent *agent)
 			length = mand_bld_ip_chassis(md, &chassis);
 			if (length > 0)
 				break;
-			/* Fall through on IP error */
-			__attribute__ ((fallthrough));
+			/* fall through on IP error */
 		case CHASSIS_ID_MAC_ADDRESS:
 		default:
 			length = mand_bld_mac_chassis(md, &chassis);
@@ -234,8 +233,7 @@ static int mand_bld_chassis_tlv(struct mand_data *md, struct lldp_agent *agent)
 			length = mand_bld_ip_chassis(md, &chassis);
 			if (length > 0)
 				break;
-			/* Fall through on IP error */
-			__attribute__ ((fallthrough));
+			/* fall through on IP error */
 		case LLDP_MED_DEVTYPE_NETWORK_CONNECTIVITY:
 		default:
 			length =  mand_bld_ifname_chassis(md, &chassis);
@@ -370,7 +368,7 @@ static int mand_bld_portid_tlv(struct mand_data *md, struct lldp_agent *agent)
 				 sizeof(portid.sub);
 			break;
 		}
-		__attribute__ ((fallthrough));
+		/* fall through */
 	case PORT_ID_NETWORK_ADDRESS:
 		/* uses ipv4 first */
 		if (!get_ipaddr(md->ifname, &portid.id.na.ip.v4)) {
@@ -390,7 +388,7 @@ static int mand_bld_portid_tlv(struct mand_data *md, struct lldp_agent *agent)
 				 sizeof(portid.sub);
 			break;
 		}
-		__attribute__ ((fallthrough));
+		/* fall through */
 	case PORT_ID_INTERFACE_NAME:
 		portid.sub = PORT_ID_INTERFACE_NAME;
 		strncpy((char *)portid.id.ifname, md->ifname, IFNAMSIZ);

--- a/lldp_med_cmds.c
+++ b/lldp_med_cmds.c
@@ -303,7 +303,7 @@ static int _set_arg_med_devtype(struct cmd *cmd, char *argvalue,
 	case LLDP_MED_DEVTYPE_ENDPOINT_CLASS_III:
 	case LLDP_MED_DEVTYPE_ENDPOINT_CLASS_II:
 		tlv_enabletx(cmd->ifname, cmd->type, (OUI_TIA_TR41 << 8) | LLDP_MED_NETWORK_POLICY);
-		__attribute__ ((fallthrough));
+		/* fall through */
 	case LLDP_MED_DEVTYPE_ENDPOINT_CLASS_I:
 	case LLDP_MED_DEVTYPE_NETWORK_CONNECTIVITY:
 		tlv_enabletx(cmd->ifname, cmd->type, (OUI_TIA_TR41 << 8) | LLDP_MED_RESERVED);

--- a/qbg/vdp22.c
+++ b/qbg/vdp22.c
@@ -455,10 +455,10 @@ static void copy_filter(unsigned char fif, struct fid22 *fp,
 		fp->grpid = from->gpid;
 		if (fif == VDP22_FFMT_GROUPVID)
 			goto vid;
-		__attribute__ ((fallthrough));
+		/* fall through */
 	case VDP22_FFMT_MACVID:
 		memcpy(fp->mac, from->mac, sizeof(fp->mac));
-		__attribute__ ((fallthrough));
+		/* fall through */
 	case VDP22_FFMT_VID:
 vid:
 		fp->vlan = vdp22_set_vlanid(from->vlan)

--- a/qbg/vdp22_cmds.c
+++ b/qbg/vdp22_cmds.c
@@ -473,7 +473,7 @@ static bool vdp22_partial_vsi_equal(struct vsi22 *p1, struct vsi22 *p2,
 			if (memcmp(p1->mgrid, p2->mgrid,
 				   sizeof(p2->mgrid)))
 				return false;
-			__attribute__ ((fallthrough));
+			/* fall through */
 		case VSI_TYPEID_ARG:
 			if (p1->type_id != p2->type_id)
 				return false;

--- a/qbg/vdp22sm.c
+++ b/qbg/vdp22sm.c
@@ -1521,7 +1521,7 @@ static void vdp22br_process(struct vsi22 *p)
 	case VDP22_RESP_DEASSOC:
 		if (error > VDP22_STATUS_MASK)
 			p->status = VDP22_HARDBIT;
-		__attribute__ ((fallthrough));
+		/* fall through */
 	case VDP22_RESP_SUCCESS:
 rest:
 		p->status |= VDP22_ACKBIT | make_status(error);


### PR DESCRIPTION
The __attribute__((fallthrough)); (used to allow falling through
cases in a switch statement) is not defined before gcc version 7.1.
To fix this there is a marker comment (see details below) so this
commit replaces the attributes by the marker comment.

Documentation for Wimplicit-fallthrough:
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough