### PR TITLE
Persistent willing

### DIFF
--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -223,7 +223,7 @@ static int read_cfg_file(char *ifname, struct lldp_agent *agent,
 	const char *arg = NULL;
 	char arg_path[256];
 	int res = 0, i;
-	int willing, pfc_mask, delay;
+	int pfc_mask, delay;
 
 	if (agent->type != NEAREST_BRIDGE)
 		return 0;

--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -213,7 +213,8 @@ bool read_cfg_file_willing(char *ifname, struct lldp_agent *agent, int tlv_type)
 	res = get_config_setting(ifname, agent->type, arg_path, &willing, 
 		CONFIG_TYPE_INT);
  	
-	return (res == 0 ? willing == 1 : true); 
+	/* willing is disabled by default */
+	return (res == 0 ? willing == 1 : false); 
 }
 
 static int read_cfg_file(char *ifname, struct lldp_agent *agent,
@@ -227,11 +228,11 @@ static int read_cfg_file(char *ifname, struct lldp_agent *agent,
 	if (agent->type != NEAREST_BRIDGE)
 		return 0;
 
-	/* Read ETS-CFG willing bit -- default willing enabled */
+	/* Read ETS-CFG willing bit -- default willing disabled */
 	tlvs->ets->cfgl->willing = read_cfg_file_willing(
 			ifname, agent, LLDP_8021QAZ_ETSCFG);
 
-	/* Read PFC willing bit -- default willing enabled */
+	/* Read PFC willing bit -- default willing disabled */
 	tlvs->pfc->local.willing = read_cfg_file_willing(
 			ifname, agent, LLDP_8021QAZ_PFC);
 


### PR DESCRIPTION
There are two commits in this merge:

8bdc723 - 8021qaz: Honor willing value from config file
Read the willing value of pfc and ets variables directly from the config file before calling set_ieee_hw. In case such value exists and its value is false, then we don't set any pfc/ets data to write to hw.

9858409 - 8021qaz: Set willing to false by default 
If the willing parameter for PFC/ETSCFG is not present in lldpad.config file, then set it to false by default.