### PR TITLE
Persistent willing2

### DIFF
--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -222,7 +222,7 @@ static int read_cfg_file(char *ifname, struct lldp_agent *agent,
 	const char *arg = NULL;
 	char arg_path[256];
 	int res = 0, i;
-	int willing, pfc_mask, delay;
+	int pfc_mask, delay;
 
 	if (agent->type != NEAREST_BRIDGE)
 		return 0;


### PR DESCRIPTION
This merge contains only changes to honor willing value from config file; The default willing value (which is enabled) has not been changed. 

There are two commits in this merge:

189f63a - 8021qaz: Honor willing value from config file
Read the willing value of pfc and ets variables directly from the config file before calling set_ieee_hw. In case such value exists and its value is false, then we don't set any pfc/ets data to write to hw.

59c9a54 - 8021qaz: Remove unused variable
Previous commit had introduced an unused variable. 