### PR TITLE
rpm-spec: Add vdp22 man files to lldpad.spec.in

### DIFF
--- a/lldpad.spec.in
+++ b/lldpad.spec.in
@@ -72,6 +72,7 @@ fi
 %{_sysconfdir}/bash_completion.d/lldptool
 %{_mandir}/man8/*
 %{_libdir}/liblldp_clif.*
+%{_mandir}/man3/liblldp_clif-vdp22.*
 
 %files devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
Add missing files man3/liblldp_clif-vdp22.* to file lldpad.spec.in
at '%files' section.