### PR TITLE
autoconf: Add systemd support in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,39 @@ then
  AC_MSG_ERROR([no suitable flex found. Please install the 'flex' package.])
 fi
 
+dnl Begin determine the systemd use and location
+PKG_CHECK_MODULES([SYSTEMD], [systemd], use_systemd=yes, use_systemd=no)
+
+dnl Set sysvinit values, if system has systemd it will be rewritten
+AC_SUBST(SPEC_BUILD_REQUIRES_POST, "chkconfig")
+AC_SUBST(SPEC_BUILD_REQUIRES_PREUN, "chkconfig initscripts")
+AC_SUBST(SPEC_BUILD_REQUIRES_POSTUN, "initscripts")
+specfile_install="%{_sysconfdir}/init.d/lldpad"
+specfile_install_socket=""
+
+if test "x$use_systemd" == xyes; then
+        dir=""
+        AC_ARG_WITH([systemdsystemunitdir],
+                AS_HELP_STRING([--with-systemdsystem unitdir=DIR],
+                 [Directory for systemd service files default from pkg-config variable systemdsystemunitdir]),
+                [dir=${withval}],
+                [dir="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])
+
+	systemdsystemunitdir=${dir}
+	AC_SUBST(SYSTEMD_SYSTEM_UNIT_DIR, [$systemdsystemunitdir])
+	specfile_install="$systemdsystemunitdir/lldpad.service"	
+	specfile_install_socket="$systemdsystemunitdir/lldpad.socket"
+
+	AC_SUBST(SPEC_BUILD_REQUIRES_POST, "systemd")
+	AC_SUBST(SPEC_BUILD_REQUIRES_PREUN, "systemd")
+	AC_SUBST(SPEC_BUILD_REQUIRES_POSTUN, "systemd")
+fi
+
+AM_CONDITIONAL(SYSTEMD_SYSTEM, test "x$use_systemd" == xyes)
+AC_SUBST(SPEC_FILE_LLDPAD_SERVICE, $specfile_install)
+AC_SUBST(SPEC_FILE_LLDPAD_SOCKET, $specfile_install_socket)
+dnl End systemd stuff
+
 PKG_CHECK_MODULES([LIBCONFIG], [libconfig >= 1.3.2])
 PKG_CHECK_MODULES([LIBNL], [libnl-3.0 >= 3.2])
 

--- a/lldpad.spec.in
+++ b/lldpad.spec.in
@@ -10,9 +10,9 @@ Source0:        http://downloads.sourceforge.net/e1000/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 # BuildRequires:  
-Requires(post):   chkconfig
-Requires(preun):  chkconfig initscripts
-Requires(postun): initscripts
+Requires(post):   @SPEC_BUILD_REQUIRES_POST@
+Requires(preun):  @SPEC_BUILD_REQUIRES_PREUN@
+Requires(postun): @SPEC_BUILD_REQUIRES_POSTUN@
 
 %description
 This package contains the Linux user space daemon and configuration tool for
@@ -46,19 +46,35 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %post
-/sbin/chkconfig --add lldpad 
+if [ -e /etc/init.d/%{name} ] && [ -e /sbin/chkconfig ]; then
+	/sbin/chkconfig --add %{name}
+fi
+if type systemctl >/dev/null 2>&1; then
+	# Scriplet only runs preset. Run enable/start manually
+	%systemd_post %{name}.socket %{name}.service
+fi
 
 %preun
 if [ $1 = 0 ]; then
-        /sbin/service lldpad stop
-        /sbin/chkconfig --del lldpad 
+	if [ -e /etc/init.d/%{name} ] && [ -e /sbin/chkconfig ]; then
+		/sbin/service %{name} stop
+		/sbin/chkconfig --del %{name}
+	fi
+	if type systemctl >/dev/null 2>&1; then
+		%systemd_preun %{name}.service %{name}.socket
+	fi
 fi
 
 %postun
 if [ $1 = 1 ]; then
-        /sbin/service lldpad condrestart
+	# Package upgrade, not uninstall
+	if [ -e /etc/init.d/%{name} ] && [ -e /sbin/chkconfig ]; then
+		/sbin/service %{name} condrestart
+	fi
+	if type systemctl >/dev/null 2>&1; then
+		%systemd_postun_with_restart %{name}.socket %{name}.service
+	fi
 fi
-
 
 %files
 %defattr(-,root,root,-)
@@ -67,7 +83,8 @@ fi
 %doc ChangeLog
 %{_sbindir}/*
 %dir /var/lib/lldpad
-%{_sysconfdir}/init.d/lldpad
+@SPEC_FILE_LLDPAD_SERVICE@
+@SPEC_FILE_LLDPAD_SOCKET@
 %{_sysconfdir}/bash_completion.d/lldpad
 %{_sysconfdir}/bash_completion.d/lldptool
 %{_mandir}/man8/*


### PR DESCRIPTION
Changes to let rpm use systemd or sysV depending on the target system
configuration.

If systemd is installed in the build system then variables
SPEC_BUILD_REQUIRES_[POST|PREUN|POSTUN] are filled with the string
'systemd', and variables SPEC_FILE_LLDPAD_[SERVICE|SOCKET] point to
files lldpad.service and lldpad.socket.

If systemd is not present in the build system then variables
SPEC_BUILD_REQUIRES_[POST|PREUN|POSTUN] are filled with 'chkconfig'
commands, and variables SPEC_FILE_LLDPAD_[SERVICE|SOCKET] point to
file '%{_sysconfdir}/init.d/lldpad'.

In both cases, file lldpad.spec.in have references to above variables.