### PR TITLE
rpm: Add fields to *.service and *.socket files

### DIFF
--- a/lldpad.service
+++ b/lldpad.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Link Layer Discovery Protocol Agent Daemon.
 After=syslog.target network.target
+Requires=lldpad.socket
 
 [Service]
 Type=simple
+Restart=always
 ExecStart=/usr/sbin/lldpad -t
 ExecReload=/bin/kill -HUP $MAINPID
 

--- a/lldpad.socket
+++ b/lldpad.socket
@@ -1,3 +1,6 @@
+[Unit]
+Description=Link Layer Discovery Protocol Agent Socket.
+
 [Socket]
 ListenDatagram=@/com/intel/lldpad
 PassCredentials=true


### PR DESCRIPTION
Add missing rules in file lldpad.service:
- Requires=lldpad.socket   # Bring up socket when service goes up
- Restart=always           # Attempt to start service when is down

and missing information in file lldpad.socket:
- Add [Unit] section with description of socket