### PR TITLE
8021qaz: Print dscp2prio map

### DIFF
--- a/test-driver
+++ b/test-driver
@@ -1,0 +1,1 @@
+/usr/share/automake-1.13/test-driver


### PR DESCRIPTION
Following definition of DSCP APP TLV with selector 5, print dscp2prio
map for DSCP APP entries instead of printing them as any other APP
entry.

DSCP standard 802.1Qcd-2015/D.2.15.3