### PR TITLE
8021qaz: Add parameter passive_8021qaz to run in read only mode

### DIFF
--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -50,6 +50,7 @@
 
 struct lldp_head lldp_head;
 struct config_t lldpad_cfg;
+extern bool passive_8021qaz;
 
 static int ieee8021qaz_check_pending(struct port *port, struct lldp_agent *);
 static void run_all_sm(struct port *port, struct lldp_agent *agent);
@@ -959,6 +960,9 @@ static int del_ieee_hw(const char *ifname, struct dcb_app *app_data)
 			   .dcb_pad = 0
 			  };
 
+	if (passive_8021qaz)
+		return 0;
+
 	nlsocket = nl_socket_alloc();
 	if (!nlsocket) {
 		LLDPAD_WARN("%s: %s: nl_handle_alloc failed\n",
@@ -1041,6 +1045,9 @@ static int set_ieee_hw(const char *ifname, struct ieee_ets *ets_data,
 			   .cmd = DCB_CMD_IEEE_SET,
 			   .dcb_pad = 0
 			  };
+
+	if (passive_8021qaz)
+		return 0;
 
 	nlsocket = nl_socket_alloc();
 	if (!nlsocket) {

--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -50,7 +50,7 @@
 
 struct lldp_head lldp_head;
 struct config_t lldpad_cfg;
-extern bool passive_8021qaz;
+extern bool read_only_8021qaz;
 
 static int ieee8021qaz_check_pending(struct port *port, struct lldp_agent *);
 static void run_all_sm(struct port *port, struct lldp_agent *agent);
@@ -960,7 +960,7 @@ static int del_ieee_hw(const char *ifname, struct dcb_app *app_data)
 			   .dcb_pad = 0
 			  };
 
-	if (passive_8021qaz)
+	if (read_only_8021qaz)
 		return 0;
 
 	nlsocket = nl_socket_alloc();
@@ -1046,7 +1046,7 @@ static int set_ieee_hw(const char *ifname, struct ieee_ets *ets_data,
 			   .dcb_pad = 0
 			  };
 
-	if (passive_8021qaz)
+	if (read_only_8021qaz)
 		return 0;
 
 	nlsocket = nl_socket_alloc();

--- a/lldp_mand_cmds.c
+++ b/lldp_mand_cmds.c
@@ -44,6 +44,9 @@
 #include "lldp/states.h"
 #include "lldp_util.h"
 #include "messages.h"
+#include "lldp_8021qaz.h"
+
+extern bool read_only_8021qaz;
 
 static int get_arg_adminstatus(struct cmd *, char *, char *, char *, int);
 static int set_arg_adminstatus(struct cmd *, char *, char *, char *, int);
@@ -595,6 +598,9 @@ int handle_test_arg(struct cmd *cmd, char *arg, char *argvalue,
 			continue;
 		if (!(ah = np->ops->get_arg_handler()))
 			continue;
+		/* 8021QAZ set operations not allowed in read-only mode */
+		if (np->id == LLDP_MOD_8021QAZ && read_only_8021qaz)
+			return cmd_no_access;
 		while (ah->arg) {
 			if (!strcasecmp(ah->arg, arg) && ah->handle_test) {
 				rval = ah->handle_test(cmd, ah->arg, argvalue,
@@ -625,6 +631,9 @@ int handle_set_arg(struct cmd *cmd, char *arg, char *argvalue,
 			continue;
 		if (!(ah = np->ops->get_arg_handler()))
 			continue;
+		/* 8021QAZ set operations not allowed in read-only mode */
+		if (np->id == LLDP_MOD_8021QAZ && read_only_8021qaz)
+			return cmd_no_access;
 		while (ah->arg) {
 			if (!strcasecmp(ah->arg, arg) && ah->handle_set) {
 				rval = ah->handle_set(cmd, ah->arg, argvalue,

--- a/lldpad.c
+++ b/lldpad.c
@@ -84,7 +84,7 @@ char *cfg_file_name = NULL;
 bool daemonize = 0;
 int loglvl = LOG_WARNING;
 int omit_tstamp;
-bool passive_8021qaz = false;
+bool read_only_8021qaz = false;
 
 static const char *lldpad_version =
 "lldpad v" VERSION_STR "\n"
@@ -138,7 +138,7 @@ static void usage(void)
 		"   -v  show version\n"
 		"   -f  use configfile instead of default\n"
 		"   -V  set syslog level\n"
-		"   -P  run in 8021qaz passive (read only) mode\n");
+		"   -R  run 8021qaz module in read_only mode\n");
 
 	exit(1);
 }
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
 	int rc = 1;
 
 	for (;;) {
-		c = getopt(argc, argv, "hdksptvf:PV:");
+		c = getopt(argc, argv, "hdksptvf:RV:");
 		if (c < 0)
 			break;
 		switch (c) {
@@ -261,8 +261,8 @@ int main(int argc, char *argv[])
 		case 'p':
 			pid_file = 0;
 			break;
-		case 'P':
-			passive_8021qaz = true;
+		case 'R':
+			read_only_8021qaz = true;
 			break;
 		case 't':
 			omit_tstamp = 1;

--- a/lldpad.c
+++ b/lldpad.c
@@ -84,6 +84,7 @@ char *cfg_file_name = NULL;
 bool daemonize = 0;
 int loglvl = LOG_WARNING;
 int omit_tstamp;
+bool passive_8021qaz = false;
 
 static const char *lldpad_version =
 "lldpad v" VERSION_STR "\n"
@@ -136,7 +137,8 @@ static void usage(void)
 		"   -t  omit timestamps in log messages\n"
 		"   -v  show version\n"
 		"   -f  use configfile instead of default\n"
-		"   -V  set syslog level\n");
+		"   -V  set syslog level\n"
+		"   -P  run in 8021qaz passive (read only) mode\n");
 
 	exit(1);
 }
@@ -236,7 +238,7 @@ int main(int argc, char *argv[])
 	int rc = 1;
 
 	for (;;) {
-		c = getopt(argc, argv, "hdksptvf:V:");
+		c = getopt(argc, argv, "hdksptvf:PV:");
 		if (c < 0)
 			break;
 		switch (c) {
@@ -258,6 +260,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			pid_file = 0;
+			break;
+		case 'P':
+			passive_8021qaz = true;
 			break;
 		case 't':
 			omit_tstamp = 1;


### PR DESCRIPTION
Add parameter passive_8021qaz to change 8021qaz module behavior
with respect to hw values. If passive_8021qaz is true, then hw
values will be updated/modified. If passive_dcbx is false, then
there will be no changes to hw.

To run in passive mode use -P option: 'lldpad -P'