### PR TITLE
lldp: Allow lldptool to modify optional TLV's content

### DIFF
--- a/include/lldp_basman_clif.h
+++ b/include/lldp_basman_clif.h
@@ -31,7 +31,7 @@ struct lldp_module *basman_cli_register(void);
 void basman_cli_unregister(struct lldp_module *);
 int basman_print_tlv(u32, u16, char *);
 
-#define ARG_IPV4_ADDR "ipv4"
-#define ARG_IPV6_ADDR "ipv6"
-
+#define ARG_IPV4_ADDR	"ipv4"
+#define ARG_IPV6_ADDR	"ipv6"
+#define ARG_TLVINFO	"info"
 #endif


### PR DESCRIPTION
Add functions [get, set, test]_arg_info in lldp_basman_cmds.c to
allow users to get or set the value of optional lldp TLVs.

Optional tlvs are (lldptool tlv name inside brackets):

[portDesc] Port description
[sysName] System name
[sysDesc] System description
[sysCap] System capabilities
[mngAddr] Management address

The format to modify a TLV content is:
	lldptool -i <ifname> -T -V sysDesc info="New Value"