### PR TITLE
8021qaz: Add parameter read_only_8021qaz to run in read only mode

### DIFF
--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -50,6 +50,7 @@
 
 struct lldp_head lldp_head;
 struct config_t lldpad_cfg;
+extern bool read_only_8021qaz;
 
 static int ieee8021qaz_check_pending(struct port *port, struct lldp_agent *);
 static void run_all_sm(struct port *port, struct lldp_agent *agent);
@@ -960,6 +961,9 @@ static int del_ieee_hw(const char *ifname, struct dcb_app *app_data)
 			   .dcb_pad = 0
 			  };
 
+	if (read_only_8021qaz)
+		return 0;
+
 	nlsocket = nl_socket_alloc();
 	if (!nlsocket) {
 		LLDPAD_WARN("%s: %s: nl_handle_alloc failed\n",
@@ -1042,6 +1046,9 @@ static int set_ieee_hw(const char *ifname, struct ieee_ets *ets_data,
 			   .cmd = DCB_CMD_IEEE_SET,
 			   .dcb_pad = 0
 			  };
+
+	if (read_only_8021qaz)
+		return 0;
 
 	nlsocket = nl_socket_alloc();
 	if (!nlsocket) {

--- a/lldp_mand_cmds.c
+++ b/lldp_mand_cmds.c
@@ -44,6 +44,9 @@
 #include "lldp/states.h"
 #include "lldp_util.h"
 #include "messages.h"
+#include "lldp_8021qaz.h"
+
+extern bool read_only_8021qaz;
 
 static int get_arg_adminstatus(struct cmd *, char *, char *, char *, int);
 static int set_arg_adminstatus(struct cmd *, char *, char *, char *, int);
@@ -595,6 +598,9 @@ int handle_test_arg(struct cmd *cmd, char *arg, char *argvalue,
 			continue;
 		if (!(ah = np->ops->get_arg_handler()))
 			continue;
+		/* 8021QAZ set operations not allowed in read-only mode */
+		if (np->id == LLDP_MOD_8021QAZ && read_only_8021qaz)
+			return cmd_no_access;
 		while (ah->arg) {
 			if (!strcasecmp(ah->arg, arg) && ah->handle_test) {
 				rval = ah->handle_test(cmd, ah->arg, argvalue,
@@ -625,6 +631,9 @@ int handle_set_arg(struct cmd *cmd, char *arg, char *argvalue,
 			continue;
 		if (!(ah = np->ops->get_arg_handler()))
 			continue;
+		/* 8021QAZ set operations not allowed in read-only mode */
+		if (np->id == LLDP_MOD_8021QAZ && read_only_8021qaz)
+			return cmd_no_access;
 		while (ah->arg) {
 			if (!strcasecmp(ah->arg, arg) && ah->handle_set) {
 				rval = ah->handle_set(cmd, ah->arg, argvalue,

--- a/lldpad.c
+++ b/lldpad.c
@@ -84,6 +84,7 @@ char *cfg_file_name = NULL;
 bool daemonize = 0;
 int loglvl = LOG_WARNING;
 int omit_tstamp;
+bool read_only_8021qaz = false;
 
 static const char *lldpad_version =
 "lldpad v" VERSION_STR "\n"
@@ -136,7 +137,8 @@ static void usage(void)
 		"   -t  omit timestamps in log messages\n"
 		"   -v  show version\n"
 		"   -f  use configfile instead of default\n"
-		"   -V  set syslog level\n");
+		"   -V  set syslog level\n"
+		"   -R  run 8021qaz module in read-only mode\n");
 
 	exit(1);
 }
@@ -236,7 +238,7 @@ int main(int argc, char *argv[])
 	int rc = 1;
 
 	for (;;) {
-		c = getopt(argc, argv, "hdksptvf:V:");
+		c = getopt(argc, argv, "hdksptvf:PV:");
 		if (c < 0)
 			break;
 		switch (c) {
@@ -258,6 +260,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			pid_file = 0;
+			break;
+		case 'R':
+			read_only_8021qaz = true;
 			break;
 		case 't':
 			omit_tstamp = 1;


### PR DESCRIPTION
Add parameter read_only_8021qaz to change 8021qaz module's behavior
with respect to hw values.

When read_only_8021qaz is false, then hw values get updated/modified
following the regular rules of the protocol.

If read_only_dcbx is true, then there will be no changes to hw and
user won't be allowed to call any 8021qaz 'set' functions. If lldptool
sends a 'set' request then the answer will be 'cmd_no_access'.

To run lldpad in read-only  mode use -R option: 'lldpad -R'