### PR TITLE
vdptool: fixed compile error for getline()

### DIFF
--- a/vdptool.c
+++ b/vdptool.c
@@ -36,6 +36,7 @@
  * set and query VSI profile settings.
  */
 
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>


### PR DESCRIPTION
vdptool.c was generating an error: implicit declaration for the
getline() function.

Signed-off-by: Laurent Charpentier <laurent_pubs@yahoo.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/open-lldp/0001-vdptool-fixed-compile-error-for-getline.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>