### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 before_install: sudo apt-get update
 install: sudo apt-get install -y libconfig-dev libnl-3-dev rpm
 before_script: ./bootstrap.sh
-script: ./configure && make && make test && sudo make install && ./contrib/build-rpm.sh
+script: ./contrib/build-rpm.sh && ./configure && make && make test && sudo make install && rpmbuild -ba lldpad.spec
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 before_install: sudo apt-get update
 install: sudo apt-get install -y libconfig-dev libnl-3-dev
 before_script: ./bootstrap.sh
+script: ./configure && make && make test && sudo make install
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 before_install: sudo apt-get update
 install: sudo apt-get install -y libconfig-dev libnl-3-dev rpm
 before_script: ./bootstrap.sh
-script: ./configure && make && make test && sudo make install && rpmbuild -ba lldpad.spec
+script: ./configure && make && make test && sudo make install && ./contrib/build-rpm.sh
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: c
 before_install: sudo apt-get update
 install: sudo apt-get install -y libconfig-dev libnl-3-dev
 before_script: ./bootstrap.sh
+
+matrix:
+  include:
+    - dist: precise
+    - dist: xenial
+    - dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: c
-compiler:
-    - gcc
-    - clang
 before_install: sudo apt-get update
 install: sudo apt-get install -y libconfig-dev libnl-3-dev
 before_script: ./bootstrap.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: c
-before_install: sudo apt-get update
+#before_install: sudo apt-get update
 install: sudo apt-get install -y libconfig-dev libnl-3-dev rpm
 before_script: ./bootstrap.sh
-script: ./contrib/build-rpm.sh && ./configure && make && make test && sudo make install && rpmbuild -ba lldpad.spec
+script: ./contrib/build-rpm.sh && ./configure && make && make test && sudo make install #&& rpmbuild -ba lldpad.spec
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c
+compiler:
+    - gcc
+    - clang
+before_install: sudo apt-get update
+install: sudo apt-get install -y libconfig-dev libnl-3-dev
+before_script: ./bootstrap.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+dist: xenial
 #before_install: sudo apt-get update
 install: sudo apt-get install -y libconfig-dev libnl-3-dev rpm
 before_script: ./bootstrap.sh
@@ -6,6 +7,43 @@ script: ./contrib/build-rpm.sh && ./configure && make && make test && sudo make 
 
 matrix:
   include:
-    - dist: precise
-    - dist: xenial
-    - dist: bionic
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+      env:
+        - CC="gcc-4.8"
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env:
+        - CC="gcc-5"
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+      env:
+        - CC="gcc-7"
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+      env:
+        - CC="gcc-8"
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-9
+      env:
+        - CC="gcc-9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: c
 before_install: sudo apt-get update
-install: sudo apt-get install -y libconfig-dev libnl-3-dev
+install: sudo apt-get install -y libconfig-dev libnl-3-dev rpm
 before_script: ./bootstrap.sh
-script: ./configure && make && make test && sudo make install
+script: ./configure && make && make test && sudo make install && rpmbuild -ba lldpad.spec
 
 matrix:
   include:

--- a/contrib/build-rpm.sh
+++ b/contrib/build-rpm.sh
@@ -6,5 +6,6 @@ sources=~/rpmbuild/SOURCES
 version="1.0.1"
 
 mkdir -p "$sources"
-git archive --prefix=lldpad-"$version"/ --format=tar.gz --output="$sources"/lldpad-"$version".tar.gz HEAD
-rpmbuild -ba lldpad.spec
+#git archive --prefix=lldpad-"$version"/ --format=tar.gz --output="$sources"/lldpad-"$version".tar.gz HEAD
+tar --transform='s:^\.:lldpad-'"$version"':' --exclude='.git*' --exclude='.travis.yml' -cvzf ../lldpad-"$version".tar.gz .
+#rpmbuild -ba lldpad.spec

--- a/contrib/build-rpm.sh
+++ b/contrib/build-rpm.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ev
+
+sources=~/rpmbuild/SOURCES
+version="1.0.1"
+
+mkdir -p "$sources"
+git archive --prefix=lldpad-"$version"/ --format=tar.gz --output="$sources"/lldpad-"$version".tar.gz HEAD
+rpmbuild -ba lldpad.spec

--- a/contrib/build-rpm.sh
+++ b/contrib/build-rpm.sh
@@ -7,5 +7,5 @@ version="1.0.1"
 
 mkdir -p "$sources"
 #git archive --prefix=lldpad-"$version"/ --format=tar.gz --output="$sources"/lldpad-"$version".tar.gz HEAD
-tar --transform='s:^\.:lldpad-'"$version"':' --exclude='.git*' --exclude='.travis.yml' -cvzf ../lldpad-"$version".tar.gz .
+tar --transform='s:^\.:lldpad-'"$version"':' --exclude='.git*' --exclude='.travis.yml' -cvzf "$sources"/lldpad-"$version".tar.gz .
 #rpmbuild -ba lldpad.spec


### PR DESCRIPTION
This branch adds in support to run a build and test on OpenLLDP automatically through Travis CI. If enabled on the main repo, this should help ensure pull requests actually compile and pass some level of testing first.