### PR TITLE
l2_packet: Guard ETH_P_LLDP define

### DIFF
--- a/lldp/l2_packet.h
+++ b/lldp/l2_packet.h
@@ -37,7 +37,9 @@
 #define IP2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
 #define IPSTR "%02x:%02x:%02x:%02x:%02x:%02x"
 
+#ifndef ETH_P_LLDP
 #define ETH_P_LLDP 0x88cc
+#endif
 
 #define ETH_P_ECP	0x88b7		/* Draft 0.2 */
 #define ETH_P_ECP22	0x8940		/* Ratified standard */


### PR DESCRIPTION
ETH_P_LLDP is now defined in if_ether.h on new kernels. Guarding this prevents
double definition when building on 5.3 kernels.

Signed-off-by: Scott Register <sreg@sreg.io>