### PR TITLE
dcbx: check for dcbx_data result

### DIFF
--- a/lldp_dcbx.c
+++ b/lldp_dcbx.c
@@ -194,6 +194,8 @@ int dcbx_bld_tlv(struct port *newport, struct lldp_agent *agent)
 		return 0;
 
 	tlvs = dcbx_data(newport->ifname);
+	if (!tlvs)
+		return 0;
 
 	get_config_setting(newport->ifname, agent->type, ARG_ADMINSTATUS,
 			  &adminstatus, CONFIG_TYPE_INT);


### PR DESCRIPTION
The dcbx_data function can return a null pointer, but the dcbx tlv function
will happily attempt to dereference.  Prevent this by checking for result
and bailing.

Fixes: a37b7e0f3b66 ("lldpad: initial git commit")
Signed-off-by: Aaron Conole <aconole@redhat.com>