### PR TITLE
Print newline for all error messages

### DIFF
--- a/config.c
+++ b/config.c
@@ -234,7 +234,7 @@ int check_cfg_file(void)
 			}
 		} else {
 			retval = errno;
-			LLDPAD_ERR("%s is not readable and writeable",
+			LLDPAD_ERR("%s is not readable and writeable\n",
 				cfg_file_name);
 		}
 	}
@@ -310,7 +310,7 @@ int get_int_config(config_setting_t *s, char *attr, int int_type,
 	}
 
 	if (!rval)
-		LLDPAD_ERR("invalid value for %s", attr);
+		LLDPAD_ERR("invalid value for %s\n", attr);
 
 	return rval;
 }
@@ -354,7 +354,7 @@ int get_array_config(config_setting_t *s, char *attr, int int_type,
 	}
 
 	if (!rval)
-		LLDPAD_ERR("invalid setting for %s", attr);
+		LLDPAD_ERR("invalid setting for %s\n", attr);
 
 	return rval;
 }

--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -112,14 +112,14 @@ struct lldp_module *ieee8021qaz_register(void)
 
 	mod = malloc(sizeof(*mod));
 	if (!mod) {
-		LLDPAD_ERR("Failed to malloc LLDP-8021QAZ module data");
+		LLDPAD_ERR("Failed to malloc LLDP-8021QAZ module data\n");
 		goto out_err;
 	}
 
 	iud = malloc(sizeof(*iud));
 	if (!iud) {
 		free(mod);
-		LLDPAD_ERR("Failed to malloc LLDP-8021QAZ module user data");
+		LLDPAD_ERR("Failed to malloc LLDP-8021QAZ module user data\n");
 		goto out_err;
 	}
 	memset((void *) iud, 0, sizeof(struct ieee8021qaz_user_data));

--- a/lldp_8023.c
+++ b/lldp_8023.c
@@ -472,13 +472,13 @@ struct lldp_module *ieee8023_register(void)
 
 	mod = malloc(sizeof(*mod));
 	if (!mod) {
-		LLDPAD_ERR("failed to malloc LLDP 802.3 module data");
+		LLDPAD_ERR("failed to malloc LLDP 802.3 module data\n");
 		goto out_err;
 	}
 	ud = malloc(sizeof(struct ieee8023_user_data));
 	if (!ud) {
 		free(mod);
-		LLDPAD_ERR("failed to malloc LLDP 802.3 module user data");
+		LLDPAD_ERR("failed to malloc LLDP 802.3 module user data\n");
 		goto out_err;
 	}
 	LIST_INIT(&ud->head);

--- a/lldp_dcbx.c
+++ b/lldp_dcbx.c
@@ -410,7 +410,7 @@ struct lldp_module * dcbx_register(void)
 	if (get_dcbx_version(&dcbx_version)) {
 		gdcbx_subtype = dcbx_version;
 	} else {
-		LLDPAD_ERR("failed to get DCBX version");
+		LLDPAD_ERR("failed to get DCBX version\n");
 		goto out_err;
 	}
 

--- a/lldp_dcbx_cfg.c
+++ b/lldp_dcbx_cfg.c
@@ -703,7 +703,7 @@ static int _set_persistent(char *device_name, int dcb_enable,
 	return 0;
 
 set_error:
-	LLDPAD_ERR("update of config file %s failed for %s",
+	LLDPAD_ERR("update of config file %s failed for %s\n",
 		   cfg_file_name, device_name);
 	return cmd_failed;
 }

--- a/qbg/ecp.c
+++ b/qbg/ecp.c
@@ -682,7 +682,7 @@ static void ecp_rx_ReceiveFrame(void *ctx, UNUSED int ifindex, const u8 *buf,
 	}
 
 	if (hdr->h_proto != example_hdr.h_proto) {
-		LLDPAD_ERR("%s:%s ERROR ethertype %#x not ECP ethertype",
+		LLDPAD_ERR("%s:%s ERROR ethertype %#x not ECP ethertype\n",
 			    __func__, vd->ecp.ifname, htons(hdr->h_proto));
 		frame_error++;
 		return;


### PR DESCRIPTION
A handful of error messages are missing newlines which messes up the prompt.