### PR TITLE
fixed unknown type pid_t

### DIFF
--- a/dcbtool_cmds.c
+++ b/dcbtool_cmds.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <sys/types.h>
 #include "clif.h"
 #include "dcbtool.h"
 #include "lldp_dcbx_cmds.h"

--- a/lldptool_cmds.c
+++ b/lldptool_cmds.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <sys/types.h>
 #include "clif.h"
 #include "dcb_types.h"
 #include "lldptool.h"


### PR DESCRIPTION
Fixed 'unknown type pid_t' gcc compile error in dcbtool_cmds.c and
lldptool_cmds.c

Signed-off-by: Laurent Charpentier <laurent_pubs@yahoo.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/open-lldp/0004-fixed-unknown-type-pid_t.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>