### PR TITLE
lldpad: add 'make rpm'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,3 +149,14 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --enable-debug
 lldp_clif_test_SOURCES = test/lldp_clif_test.c lldp_basman_clif.c lldp_util.c \
 	lldp_rtnl.c
 lldp_clif_test_LDFLAGS = -lrt $(LIBNL_LIBS)
+
+RPMBUILD_TOP = $(abs_top_builddir)/rpm/rpmbuild
+RPMBUILD_OPT ?= --without check
+
+# Build user-space RPMs
+rpm: dist $(srcdir)/lldpad.spec
+	${MKDIR_P} ${RPMBUILD_TOP}/SOURCES
+	cp ${DIST_ARCHIVES} ${RPMBUILD_TOP}/SOURCES
+	rpmbuild ${RPMBUILD_OPT} \
+                 -D "_topdir ${RPMBUILD_TOP}" \
+                 -ba $(srcdir)/lldpad.spec


### PR DESCRIPTION
Add a convenience target to build RPMs for easier testing.

Signed-off-by: Aaron Conole <aconole@redhat.com>