### PR TITLE
lldp: do not call 'assert' in rxProcessFrame()

### DIFF
--- a/lldp/rx.c
+++ b/lldp/rx.c
@@ -139,7 +139,16 @@ void rxProcessFrame(struct port *port, struct lldp_agent *agent)
 	int err;
 	struct lldp_module *np;
 
-	assert(agent->rx.framein && agent->rx.sizein);
+	if (!agent->rx.framein) {
+		LLDPAD_DBG("ERROR - agent framein not set, "
+			   "has the neighbour MAC changed? "
+			   "Ignoring packet.\n");
+		return;
+	}
+	if (!agent->rx.sizein) {
+		LLDPAD_DBG("Size-0 packet received, ignoring packet\n");
+		return;
+	}
 	agent->lldpdu = 0;
 	agent->rx.dupTlvs = 0;
 


### PR DESCRIPTION
The state machine might have called 'DELETE' just before RX got
triggered, so we might end up having no frame to process.
If so just ignore this packet.

Signed-off-by: Hannes Reinecke <hare@suse.de>