### PR TITLE
Add --{en,dis}able-werror

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,10 @@ ACLOCAL_AMFLAGS = -I m4
 parse_cli.o: CFLAGS+=-U_FORTIFY_SOURCE -Wno-error
 
 ## system requires a shared libconfig
-AM_CFLAGS = -Wall -Werror -Wextra -Wformat=2 $(LIBCONFIG_CFLAGS) $(LIBNL_CFLAGS)
+AM_CFLAGS = -Wall -Wextra -Wformat=2 $(LIBCONFIG_CFLAGS) $(LIBNL_CFLAGS)
+if BUILD_WERROR
+AM_CFLAGS += -Werror
+endif
 AM_LDFLAGS = $(LIBCONFIG_LIBS) $(LIBNL_LIBS) -lrt
 
 ## header files to be installed, for programs using the client interface to lldpad 

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,11 @@ if test "$enable_debug" = "yes" ; then
 fi
 AM_CONDITIONAL([BUILD_DEBUG], [test "$enable_debug" = "yes"])
 
+AC_ARG_ENABLE(werror,
+	AS_HELP_STRING([--enable-werror],[compile with -Werror]),
+	[enable_werror=$enableval], [enable_werror=yes])
+AM_CONDITIONAL([BUILD_WERROR], [test "$enable_werror" = "yes"])
+
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX


### PR DESCRIPTION
Allow the user to disable -Werror (it remains enabled by default).
This will allow buildroot to drop the following patch:
https://git.buildroot.net/buildroot/tree/package/open-lldp/0002-Makefile.am-disable-Werror.patch

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>