### PR TITLE
travis-ci: Add gcc10 check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,12 @@ matrix:
             - gcc-9
       env:
         - CC="gcc-9"
+    - addons:
+        apt:
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+          packages:
+            - gcc-10
+      env:
+        - CC="gcc-10"
+      dist: bionic


### PR DESCRIPTION
Note gcc-10 checks are being done on Bionic instead of Focal since there is a
bug in Focal's version of gcc-10 (at time of writing) which was reporting false 
failures: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94647

Signed-off-by: Scott Register <scottx.register@intel.com>