### PR TITLE
tx: when operating in rx-only mode don't send a port shutdown pdu

### DIFF
--- a/lldp/agent.c
+++ b/lldp/agent.c
@@ -200,7 +200,7 @@ void clean_lldp_agents(void)
 			LLDPAD_DBG("Send shutdown frame on port %s\n",
 				port->ifname);
 			LIST_FOREACH(agent, &port->agent_head, entry) {
-				process_tx_shutdown_frame(port, agent);
+				process_tx_shutdown_frame(port, agent, false);
 			}
 		} else {
 			LLDPAD_DBG("No shutdown frame is sent on port %s\n",

--- a/lldp/states.h
+++ b/lldp/states.h
@@ -85,7 +85,7 @@ u8 txFrame(struct port *port, struct lldp_agent *);
 void run_tx_sm(struct port *, struct lldp_agent *);
 void process_tx_initialize_sm(struct port *);
 void process_tx_idle(struct lldp_agent *);
-void process_tx_shutdown_frame(struct port *, struct lldp_agent *);
+void process_tx_shutdown_frame(struct port *, struct lldp_agent *, bool);
 void process_tx_info_frame(struct port *, struct lldp_agent *);
 void update_tx_timers(struct lldp_agent *);
 void run_tx_timers_sm(struct port *, struct lldp_agent *);


### PR DESCRIPTION
Currently, lldpad correctly transmits a shutdown pdu with ttl = 0s when
transitioning from rxtx or txonly to rxonly.  However, when we shutdown
lldpad it will transmit a shutdown pdu even if the port is configured
to rxonly mode.  For some implementations of LLDP this can create
a confusing state and lead to issues in the network.  Correct this by
only transmitting a shutdown PDU when going from any transmit mode to
a receive only mode, and don't transmit PDUs on shutdown if the port
agent isn't configured to transmit.

Reported-by: Matthew Whitehead <mwhitehe@redhat.com>
Reported-at: https://bugzilla.redhat.com/show_bug.cgi?id=1905210
Signed-off-by: Aaron Conole <aconole@redhat.com>