### PR TITLE
event_iface: only set rcv buf size if too small

### DIFF
--- a/include/qbg_vdpnl.h
+++ b/include/qbg_vdpnl.h
@@ -33,6 +33,7 @@
 #include <linux/if_ether.h>
 
 #define	MAX_PAYLOAD	4096	/* Maximum Payload Size */
+#define	MIN_RCVBUF_SIZE	(MAX_PAYLOAD << 5)	/* SO_RCVBUF min */
 
 enum {
 	vdpnl_nlf1 = 1,		/* Netlink message format 1 (draft 0.2) */


### PR DESCRIPTION
Instead of always setting the receive buffer size
to a small 8K, which causes problems when a flood of
netlink messages are received, set it to a
"minimal" value only if it is currently less
than that value.

The value used is 32 x the MAX_PAYLOAD size
of 4k, i.e. 128k.

A config value to modify this can be added if needed,
but doesn't seem warranted at this time.

Changes in V2:
* remove unneeded debugging/logging