### PR TITLE
agent: reset frame status on message delete  Currently, when the agent state machine transitions out of DELETE_INFO, it leaves the rcvFrame flag set. This flag should be cleared since the frame info is no longer considered usable.  Signed-off-by: Rajesh B M bmrajesh@gmail.com

### DIFF
--- a/lldp/rx.c
+++ b/lldp/rx.c
@@ -568,6 +568,7 @@ void process_delete_info(struct port *port, struct lldp_agent *agent)
 
 	agent->rx.sizein = 0;
 	agent->rx.remoteChange = true;
+	agent->rx.rcvFrame = false;
 	return;
 }
 


### PR DESCRIPTION
There could be a core at 
assert(agent->rx.framein && agent->rx.sizein); 
in rxProcessFrame().
This is most likely due to state transition from DELETE_INFO to RX_FRAME.
When we delete a frame in process_delete_info() we should also set:
agent->rx.rcvFrame = false;

Thanks & Regards,
Rajesh