### PR TITLE
Static analysis scan fixes

### DIFF
--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -1563,47 +1563,62 @@ static bool unpack_ieee8021qaz_tlvs(struct port *port,
 	/* Process */
 	switch (tlv->info[OUI_SIZE]) {
 	case IEEE8021QAZ_ETSCFG_TLV:
-		if (tlvs->rx->etscfg == NULL) {
+		if (tlvs->rx && tlvs->rx->etscfg == NULL) {
 			tlvs->ieee8021qazdu |= RCVD_IEEE8021QAZ_TLV_ETSCFG;
 			tlvs->rx->etscfg = tlv;
-		} else {
+		} else if (tlvs->rx) {
 			LLDPAD_WARN("%s: %s: 802.1Qaz Duplicate ETSCFG TLV\n",
 				__func__, port->ifname);
 			agent->rx.dupTlvs |= DUP_IEEE8021QAZ_TLV_ETSCFG;
 			return false;
+		} else {
+			LLDPAD_INFO("%s: %s: 802.1Qaz port IFDOWN\n",
+				__func__, port->ifname);
+			return false;
 		}
 		break;
 	case IEEE8021QAZ_ETSREC_TLV:
-		if (tlvs->rx->etsrec == NULL) {
+		if (tlvs->rx && tlvs->rx->etsrec == NULL) {
 			tlvs->ieee8021qazdu |= RCVD_IEEE8021QAZ_TLV_ETSREC;
 			tlvs->rx->etsrec = tlv;
-		} else {
+		} else if (tlvs->rx) {
 			LLDPAD_WARN("%s: %s: 802.1Qaz Duplicate ETSREC TLV\n",
 				__func__, port->ifname);
 			agent->rx.dupTlvs |= DUP_IEEE8021QAZ_TLV_ETSREC;
 			return false;
+		} else {
+			LLDPAD_INFO("%s: %s: 802.1Qaz port IFDOWN\n",
+				__func__, port->ifname);
+			return false;
 		}
 		break;
-
 	case IEEE8021QAZ_PFC_TLV:
-		if (tlvs->rx->pfc == NULL) {
+		if (tlvs->rx && tlvs->rx->pfc == NULL) {
 			tlvs->ieee8021qazdu |= RCVD_IEEE8021QAZ_TLV_PFC;
 			tlvs->rx->pfc = tlv;
-		} else {
+		} else if (tlvs->rx) {
 			LLDPAD_WARN("%s: %s: 802.1Qaz Duplicate PFC TLV\n",
 				__func__, port->ifname);
 			agent->rx.dupTlvs |= DUP_IEEE8021QAZ_TLV_PFC;
 			return false;
+		} else {
+			LLDPAD_INFO("%s: %s: 802.1Qaz port IFDOWN\n",
+				__func__, port->ifname);
+			return false;
 		}
 		break;
 	case IEEE8021QAZ_APP_TLV:
-		if (tlvs->rx->app == NULL) {
+		if (tlvs->rx && tlvs->rx->app == NULL) {
 			tlvs->ieee8021qazdu |= RCVD_IEEE8021QAZ_TLV_APP;
 			tlvs->rx->app = tlv;
-		} else {
+		} else if (tlvs->rx) {
 			LLDPAD_WARN("%s: %s: 802.1Qaz Duplicate APP TLV\n",
 				    __func__, port->ifname);
 			agent->rx.dupTlvs |= DUP_IEEE8021QAZ_TLV_APP;
+			return false;
+		} else {
+			LLDPAD_INFO("%s: %s: 802.1Qaz port IFDOWN\n",
+				__func__, port->ifname);
 			return false;
 		}
 		break;
@@ -1891,26 +1906,26 @@ static void ieee8021qaz_mibUpdateObjects(struct port *port)
 
 	tlvs = ieee8021qaz_data(port->ifname);
 
-	if (tlvs->rx->etscfg) {
+	if (tlvs->rx && tlvs->rx->etscfg) {
 		process_ieee8021qaz_etscfg_tlv(port);
 	} else if (tlvs->ets->cfgr) {
 		free(tlvs->ets->cfgr);
 		tlvs->ets->cfgr = NULL;
 	}
 
-	if (tlvs->rx->etsrec) {
+	if (tlvs->rx && tlvs->rx->etsrec) {
 		process_ieee8021qaz_etsrec_tlv(port);
 	} else if (tlvs->ets->recr) {
 		free(tlvs->ets->recr);
 		tlvs->ets->recr = NULL;
 	}
 
-	if (tlvs->rx->pfc)
+	if (tlvs->rx && tlvs->rx->pfc)
 		process_ieee8021qaz_pfc_tlv(port);
 	else if (tlvs->pfc)
 		tlvs->pfc->remote_param = false;
 
-	if (tlvs->rx->app)
+	if (tlvs->rx && tlvs->rx->app)
 		process_ieee8021qaz_app_tlv(port);
 	else
 		ieee8021qaz_app_reset(&tlvs->app_head);

--- a/lldp_8021qaz_clif.c
+++ b/lldp_8021qaz_clif.c
@@ -253,7 +253,7 @@ static void ieee8021qaz_print_app_tlv(u16 len, char *info)
 {
 	u8 app, app_idx, app_prio, app_sel;
 	u16 proto, offset = 2;
-	u8 dscp[MAX_USER_PRIORITIES][MAX_APP_ENTRIES];
+	u8 dscp[MAX_USER_PRIORITIES][MAX_APP_ENTRIES] = {0};
 	u8 dscp_count[MAX_USER_PRIORITIES] = {0};
 	u8 i, j;
 	bool first_app = true;

--- a/lldp_util.c
+++ b/lldp_util.c
@@ -681,7 +681,7 @@ int is_macvtap(const char *ifname)
 	s = socket(PF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
 
 	if (s < 0) {
-		goto out;
+		return false;
 	}
 
 	nlh = malloc(NLMSG_SIZE);

--- a/qbg/vdp22_cmds.c
+++ b/qbg/vdp22_cmds.c
@@ -577,7 +577,7 @@ static int get_arg_vsi(struct cmd *cmd, char *arg, char *argvalue,
 	memset(&vsi, 0, sizeof(vsi));
 	memset(vsi_str, 0, sizeof(vsi_str));
 	vsi.request = cmd->tlvid;
-	strncpy(vsi.ifname, cmd->ifname, sizeof(vsi.ifname));
+	STRNCPY_TERMINATED(vsi.ifname, cmd->ifname, sizeof(vsi.ifname));
 	good_cmd = cmd_failed;
 	if ((cmd->ops & op_config) && (cmd->ops & op_arg)) {
 		memset(&mac, 0, sizeof(mac));


### PR DESCRIPTION
After a quick run through coverity and GCC's experimental scanner, a number of
issues were flagged.  While some were false positives, on some closer looks, it seems
that some are real issues.  None seem to be security issues, but all need to be addressed.

The bulk are errors during error processing.  These should almost never occur, but we fix
them here.

Signed-off-by: Aaron Conole <aconole@redhat.com>