### PR TITLE
Revert "Use interface index instead of name in libconfig"

### DIFF
--- a/config.c
+++ b/config.c
@@ -56,21 +56,6 @@
 config_t lldpad_cfg;
 
 /*
- * config_ifkey - Generates a config key
- *
- * Given an interface name this functions generates
- * a key (based on interface's index) suitable
- * to pass to libconfig.
- *
- */
-void config_ifkey(const char *name, char *ifkey) {
-	int index = if_nametoindex(name);
-	
-	if(index)
-		sprintf(ifkey, "if%d", index);
-}
-
-/*
  * init_cfg - initialze the global lldpad_cfg via config_init
  *
  * Returns true (1) for succes and false (0) for failed
@@ -466,15 +451,14 @@ static int lookup_config_value(char *path, union cfg_get v, int type)
 int get_config_setting(const char *ifname, int agenttype, char *path,
 		       union cfg_get v, int type)
 {
-	char p[1024], ifkey[IFNAMSIZ];
+	char p[1024];
 	int rval = CONFIG_FALSE;
 	const char *section = agent_type2section(agenttype);
 
 	/* look for setting in section->ifname area first */
 	if (ifname) {
-		config_ifkey(ifname, ifkey);
 		snprintf(p, sizeof(p), "%s.%s.%s",
-			 section, ifkey, path);
+			 section, ifname, path);
 		rval = lookup_config_value(p, v, type);
 	}
 
@@ -491,16 +475,15 @@ int get_config_setting(const char *ifname, int agenttype, char *path,
 int remove_config_setting(const char *ifname, int agenttype, char *parent,
 			  char *name)
 {
-	char p[1024], ifkey[IFNAMSIZ];
+	char p[1024];
 	int rval = CONFIG_FALSE;
 	config_setting_t *setting = NULL;
 	const char *section = agent_type2section(agenttype);
 
 	/* look for setting in section->ifname area first */
-	if (ifname) { 
-		config_ifkey(ifname, ifkey);
+	if (ifname) {
 		snprintf(p, sizeof(p), "%s.%s.%s",
-			 section, ifkey, parent);
+			 section, ifname, parent);
 		setting = config_lookup(&lldpad_cfg, p);
 	}
 
@@ -587,17 +570,15 @@ int set_config_setting(const char *ifname, int agenttype, char *path,
 		       union cfg_set v, int type)
 {
 	config_setting_t *setting = NULL;
-	char p[1024], ifkey[IFNAMSIZ];
+	char p[1024];
 	int rval = cmd_success;
 	const char *section = agent_type2section(agenttype);
 
 	LLDPAD_DBG("%s(%i): \n", __func__, __LINE__);
 
-	if (strlen(ifname)){
-		config_ifkey(ifname, ifkey);
+	if (strlen(ifname))
 		snprintf(p, sizeof(p), "%s.%s.%s",
-			 section, ifkey, path);
-	}
+			 section, ifname, path);
 	else
 		snprintf(p, sizeof(p), "%s.%s.%s",
 			 section, LLDP_COMMON, path);

--- a/include/config.h
+++ b/include/config.h
@@ -111,7 +111,4 @@ void destroy_cfg(void);
 int check_cfg_file(void);
 int check_for_old_file_format(void);
 void init_ports(void);
-
-void config_ifkey(const char *name, char *ifkey);
-
 #endif /* _CONFIG_H_ */

--- a/lldp_dcbx_cfg.c
+++ b/lldp_dcbx_cfg.c
@@ -99,15 +99,12 @@ static config_setting_t *construct_new_setting(char *device_name)
 	config_setting_t *tmp2_setting = NULL;
 	char abuf[32];
 	int i;
-	char device_name_sanitized[IFNAMSIZ];
 
 	dcbx_setting = config_lookup(&lldpad_cfg, DCBX_SETTING);
 	if (!dcbx_setting)
 		return NULL;
 
-	config_ifkey(device_name, device_name_sanitized);
-
-	eth_setting = config_setting_add(dcbx_setting, device_name_sanitized,
+	eth_setting = config_setting_add(dcbx_setting, device_name,
 		CONFIG_TYPE_GROUP);
 	if (!eth_setting)
 		goto set_error;
@@ -374,13 +371,11 @@ static int _set_persistent(char *device_name, int dcb_enable,
 	config_setting_t *setting_value = NULL;
 	char abuf[2*DCB_MAX_TLV_LENGTH + 1];
 	int result, i;
-	char device_name_sanitized[IFNAMSIZ];
 
 	dcbx_setting = config_lookup(&lldpad_cfg, DCBX_SETTING);
-	config_ifkey(device_name, device_name_sanitized);
 	if (dcbx_setting)
 		eth_settings = config_setting_get_member(dcbx_setting,
-							 device_name_sanitized);
+							 device_name);
 
 	/* init the internal data store for device_name */
 	if (NULL == eth_settings) {
@@ -787,15 +782,13 @@ int get_persistent(char *device_name, full_dcb_attribs *attribs)
 	int result = cmd_failed, i;
 	int results[MAX_USER_PRIORITIES];
 	int len;
-	char abuf[32], device_name_sanitized[IFNAMSIZ];
+	char abuf[32];
 
 	memset(attribs, 0, sizeof(*attribs));
 	dcbx_setting = config_lookup(&lldpad_cfg, DCBX_SETTING);
-
-	config_ifkey(device_name, device_name_sanitized);
 	if (dcbx_setting)
-		eth_settings = config_setting_get_member(dcbx_setting, 
-							 device_name_sanitized);
+		eth_settings = config_setting_get_member(dcbx_setting,
+							 device_name);
 
 	/* init the internal data store for device_name */
 	result = get_default_persistent(device_name, attribs);
@@ -1074,16 +1067,13 @@ int get_dcb_enable_state(char *ifname, int *result)
 	int rc = EINVAL;
 	config_setting_t *settings = NULL;
 	char path[sizeof(DCBX_SETTING) + IFNAMSIZ + 16];
-	char ifkey[IFNAMSIZ];
-
-	config_ifkey(ifname, ifkey);
 
 	memset(path, 0, sizeof(path));
-	snprintf(path, sizeof(path), "%s.%s.dcb_enable", DCBX_SETTING, ifkey); 
+	snprintf(path, sizeof(path), "%s.%s.dcb_enable", DCBX_SETTING, ifname);
 	settings = config_lookup(&lldpad_cfg, path);
 	if (!settings) {
 		LLDPAD_INFO("### %s:%s:failed on %s\n", __func__, ifname, path);
-		snprintf(path, sizeof(path), "%s.dcb_enable", ifkey); 
+		snprintf(path, sizeof(path), "%s.dcb_enable", ifname);
 		settings = config_lookup(&lldpad_cfg, path);
 		if (!settings) {
 			LLDPAD_INFO("### %s:%s:failed again %s\n", __func__, ifname, path);


### PR DESCRIPTION
This reverts commit e272d34f45bc15d52424228f824c1ad96932867e.

During production, it was found that the ifindex can be unstable.
See discussion at https://github.com/intel/openlldp/pull/3

Signed-off-by: Aaron Conole <aconole@redhat.com>