### PR TITLE
basman: use return address when pulling address

### DIFF
--- a/lldp_basman.c
+++ b/lldp_basman.c
@@ -515,7 +515,7 @@ static int basman_bld_manaddr_tlv(struct basman_data *bd,
 	if (rc) {
 		rc = basman_get_manaddr_sub(bd, agent, MANADDR_IPV6);
 		if (rc)
-			basman_get_manaddr_sub(bd, agent, MANADDR_ALL802);
+			rc = basman_get_manaddr_sub(bd, agent, MANADDR_ALL802);
 	}
 out_err:
 	return rc;


### PR DESCRIPTION
The managed address pulling routine will fail to reset the return
value from a previous attempt if no IPv4 and IPv6 addresses are
available.  Use the return address of the hwaddr fetch.

Resolves: https://github.com/intel/openlldp/issues/82
Signed-off-by: Aaron Conole <aconole@redhat.com>