### PR TITLE
lldpad: ieee8023: reorder disabling pMAC and disabling MM TX

### DIFF
--- a/lldp_8023.c
+++ b/lldp_8023.c
@@ -438,10 +438,10 @@ static void ieee8023_add_eth_caps_teardown(struct ieee8023_data *bd,
 	 * by lldpad in the first place.
 	 */
 	if (bd->enabled_preemption) {
-		ethtool_mm_change_pmac_enabled(ud->ethtool_sk, bd->ifname,
-					       false);
 		ethtool_mm_change_tx_enabled(ud->ethtool_sk, bd->ifname, false,
 					     false, 10);
+		ethtool_mm_change_pmac_enabled(ud->ethtool_sk, bd->ifname,
+					       false);
 	}
 }
 


### PR DESCRIPTION
ieee8023_add_eth_caps_teardown() tries to clean up the state of the MAC Merge layer, and it does this in two steps (ethtool netlink socket messages). The first disables the pMAC, and the second disables the TX direction of the MAC Merge layer.

Although the final state is valid, the intermediary state (where the pMAC is globally disabled, but TX is still enabled) isn't really. The kernel is trying to add sanitization to prevent entering this invalid state, and this is how it was noticed.

By reordering the calls to ethtool_mm_change_tx_enabled() and ethtool_mm_change_pmac_enabled(), the system does not go through any invalid intermediary state.

Link: https://lore.kernel.org/netdev/20230415173454.3970647-3-vladimir.oltean@nxp.com/
Fixes: 5d54c31b24ce ("lldpad: ieee8023: add Additional Ethernet Capabilities TLV logic")