### PR TITLE
lldpad: dcbx: prevent null dereference in dcbx_free_data

### DIFF
--- a/lldp_dcbx.c
+++ b/lldp_dcbx.c
@@ -306,6 +306,10 @@ void dcbx_free_tlv(struct dcbx_tlvs *tlvs)
 	if (tlvs->dcbx2)
 		free_unpkd_tlv(tlvs->dcbx2);
 
+	tlvs->control = tlvs->pg1 = tlvs->pg2 = tlvs->pfc1 =
+		tlvs->pfc2 = tlvs->app1 = tlvs->app2 = tlvs->llink =
+		tlvs->dcbx1 = tlvs->dcbx2 = NULL;
+
 	return;
 }
 
@@ -325,7 +329,6 @@ struct packed_tlv* dcbx_gettlv(struct port *port, struct lldp_agent *agent)
 		return NULL;
 
 	dcbx_free_tlv(tlvs);
-	memset(tlvs, 0, sizeof(struct dcbx_tlvs));
 
 	dcbx_bld_tlv(port, agent);
 	if (tlvs->dcbx_st == DCBX_SUBTYPE2) {


### PR DESCRIPTION
Clearing the TLV with memset clears the list data corrupting the list resulting in a null dereference in dcbx_free_data when encountering such an object.

Fixes #96