### PR TITLE
lldpad: fix using uninitialized value

### DIFF
--- a/lldptool_cmds.c
+++ b/lldptool_cmds.c
@@ -540,7 +540,7 @@ void print_cmd_response(char *ibuf, int status)
 	if (len < sizeof(cmd.ifname)) {
 		memcpy(cmd.ifname, ibuf+CMD_IF, len);
 	} else {
-		printf("Response ifname too long: %*s\n", (int)len, cmd.ifname);
+		printf("Response ifname too long: %*s\n", (int)len, ibuf + CMD_IF);
 		return;
 	}
 	cmd.ifname[len] = '\0';

--- a/vdptool.c
+++ b/vdptool.c
@@ -629,7 +629,7 @@ static void print_cmd_response(char *ibuf, int status)
 	if (len < sizeof(cmd.ifname)) {
 		memcpy(cmd.ifname, ibuf + CMD_IF, len);
 	} else {
-		printf("Response ifname too long: %*s\n", (int)len, cmd.ifname);
+		printf("Response ifname too long: %*s\n", (int)len, ibuf + CMD_IF);
 		return;
 	}
 	cmd.ifname[len] = '\0';


### PR DESCRIPTION
When the length is less than sizeof(cmd.ifname), the cmd.ifname will be printed uninitialized, which could cause information leakage. Fix this by copying the maximum size of ifname before printing it out.

This issue was found through static code analysis.

Fixes: a37b7e0f3b66 ("lldpad: initial git commit")
Fixes: 3b559d8d0b52 ("VDP: vdptool first version")