### PR TITLE
lldpad: free the memory allocted by strdup

### DIFF
--- a/lldp_8021qaz.c
+++ b/lldp_8021qaz.c
@@ -210,6 +210,7 @@ static int read_cfg_file(char *ifname, struct lldp_agent *agent,
 	char arg_path[256];
 	int res = 0, i;
 	int willing, pfc_mask, delay;
+	char *parse = NULL;
 
 	if (agent->type != NEAREST_BRIDGE)
 		return 0;
@@ -354,7 +355,6 @@ static int read_cfg_file(char *ifname, struct lldp_agent *agent,
 
 	/* Read and add APP data to internal lldpad APP ring */
 	for (i = 0; i < MAX_APP_ENTRIES; i++) {
-		char *parse;
 		char *app_tuple;
 		u8 prio, sel;
 		long pid;
@@ -391,8 +391,10 @@ static int read_cfg_file(char *ifname, struct lldp_agent *agent,
 			ieee8021qaz_mod_app(&tlvs->app_head, 0,
 					    prio, sel, (u16) pid, 0);
 		free(parse);
+		parse = NULL;
 	}
 
+	free(parse);
 	return 0;
 }
 


### PR DESCRIPTION
There are some strdup calls that are not freed after use. Let's free them to avoid resource leaks.

This issue was found through static code analysis.

Fixes: b4f9ebc96e0c ("lldpad: implement APP TLV set/get commands")
Fixes: 0313734d05cc ("lldpad: correct IEEE DCBX capabilities check")