### PR TITLE
Enable automatic Build CI for code pushes and pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        version: [7, 8, 10, 11]
 
     runs-on: ubuntu-20.04
 
@@ -15,7 +18,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get install -y libconfig-dev libnl-3-dev libnl-genl-3-dev linux-libc-dev rpm
+        run: >
+          sudo apt-get install -y
+          libconfig-dev libnl-3-dev libnl-genl-3-dev
+          linux-libc-dev rpm
+
+      - name: Set up GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: ${{ matrix.version }}
+          platform: x64
 
       - name: Run bootstrap
         run: ./bootstrap.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [7, 8, 10, 11]
+        #version: [7, 8, 10, 11]
+        version: [7, 8, 9]
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt-get install -y libconfig-dev libnl-3-dev libnl-genl-3-dev linux-libc-dev rpm
+
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+
+      - name: Build RPM
+        run: ./contrib/build-rpm.sh
+
+      - name: Configure project
+        run: ./configure --enable-errors
+
+      - name: Build
+        run: make
+
+      - name: Run check
+        run: make check
+
+      - name: Install
+        run: sudo make install
+
+      - name: Run distcheck
+        run: make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,9 +47,9 @@ include/lldp_evb22_clif.h include/qbg_vdp_clif.h include/qbg_vdpnl.h \
 include/qbg_vdp22_clif.h include/lldp_8021qaz_clif.h \
 include/lldp_orgspec_clif.h include/lldp_cisco_clif.h \
 include/lldptool.h include/lldp_rtnl.h include/dcbtool.h include/lldp_dcbx_cfg.h \
-include/qbg_vdp22_cmds.h include/qbg_vdp22_clif.h \
-include/linux/ethtool.h include/linux/if_bonding.h include/linux/if_bridge.h \
-include/linux/if.h include/linux/if_link.h include/linux/if_vlan.h
+include/qbg_vdp22_cmds.h include/qbg_vdp22_clif.h include/linux/ethtool.h \
+include/linux/if_bonding.h include/linux/if_bridge.h include/linux/if.h \
+include/linux/if_link.h include/linux/if_vlan.h include/linux/ethtool_netlink.h
 
 lldpad_SOURCES = lldpad.c config.c lldp_dcbx_nl.c ctrl_iface.c \
 event_iface.c eloop.c lldp_dcbx_cmds.c log.c lldpad_shm.c \


### PR DESCRIPTION
This enables a full CI build for each push to GitHub to validate the current state of the code on all branches and pull requests to master. This tests the build with multiple GCC versions, but I would like to add a few more. This is to replace the older Travis CI build system which is no longer provides for free to open source projects. This is configured to automatically trigger for PRs and show as part of the status to help quickly weed out build issues with them.

- **Enabled CI build for GitHub Actions**
- **Added missing header to build**
- **Added matrix of GCC versions**
- **Limit matrix to known, good GCC versions**

If you are curious about the missing header fix above, you can see the build failure due to it on this previous run:

https://github.com/penguin359/openlldp/actions/runs/9814786001/job/27102902583#step:10:427
