### PR TITLE
lldpad: using inet_ntop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ AC_CHECK_LIB(nl3, rtnl_link_get_by_name)
 
 AC_CHECK_FUNCS([alarm])
 AC_CHECK_FUNCS([gettimeofday])
-AC_CHECK_FUNCS([inet_ntoa])
+AC_CHECK_FUNCS([inet_ntop])
 AC_CHECK_FUNCS([localtime_r])
 AC_CHECK_FUNCS([memmove])
 AC_CHECK_FUNCS([memset])

--- a/lldp_util.c
+++ b/lldp_util.c
@@ -1092,7 +1092,8 @@ int get_ipaddrstr(const char *ifname, char *ipaddr, size_t size)
 	rc = get_saddr(ifname, &sa);
 	if (rc == 0) {
 		memset(ipaddr, 0, size);
-		strncpy(ipaddr, inet_ntoa(sa.sin_addr), size);
+		if (inet_ntop(AF_INET, &sa.sin_addr, ipaddr, size) == NULL)
+			rc = errno;
 	}
 	return rc;
 }

--- a/qbg/vdp22cisco_oui.c
+++ b/qbg/vdp22cisco_oui.c
@@ -130,13 +130,13 @@ bool cisco_str2vdpnl_hndlr(struct vdpnl_oui_data_s *vdp_oui_p, char *token)
 				return false;
 			}
 			strncpy(v4_addr_str, token, data_len);
-			ret = inet_aton(v4_addr_str,
+			ret = inet_pton(AF_INET, v4_addr_str,
 					&vdp_cisco_oui_p->l3_addr.ipv4_address);
 			LLDPAD_DBG("V4adr %s 0x%lx\n", v4_addr_str,
 				   (unsigned long)
 				  vdp_cisco_oui_p->l3_addr.ipv4_address.s_addr);
 			free(v4_addr_str);
-			if (!ret) {
+			if (ret <= 0) {
 				LLDPAD_ERR("%s: Incorrect addr\n", __func__);
 				return false;
 			}

--- a/vdptool_cisco_oui.c
+++ b/vdptool_cisco_oui.c
@@ -66,6 +66,7 @@ void cisco_oui_print_decode_hndlr(char *token)
 	u16 data_len;
 	u8 key_len;
 	enum oui_key_arg oui_argtype;
+	char addr[INET_ADDRSTRLEN];
 
 	if (token == NULL)
 		return;
@@ -99,8 +100,10 @@ void cisco_oui_print_decode_hndlr(char *token)
 			strncpy(v4_addr_str, token, data_len);
 			vm_ip_addr = strtoul(v4_addr_str, NULL, 10);
 			vm_inet.s_addr = vm_ip_addr;
+			if (inet_ntop(AF_INET, &vm_inet, addr, INET_ADDRSTRLEN) == NULL)
+				return;
 			printf("\t%s", "VM IP Address");
-			printf(" = %s\n", inet_ntoa(vm_inet));
+			printf(" = %s\n", addr);
 			free(v4_addr_str);
 			break;
 		default:


### PR DESCRIPTION
Function inet_ntoa is deprecated. Use inet_ntop instead. Also convert inet_aton to inet_pton.