### PR TITLE
lldpad: remove device from config file when ports are removed

### DIFF
--- a/config.c
+++ b/config.c
@@ -472,6 +472,32 @@ int get_config_setting(const char *ifname, int agenttype, char *path,
 	return (rval == CONFIG_FALSE) ? cmd_failed : cmd_success;
 }
 
+int remove_config_device(const char *ifname, int agenttype)
+{
+	const char *section = agent_type2section(agenttype);
+	config_setting_t *setting = NULL;
+	int rval = cmd_failed;
+
+	setting = config_lookup(&lldpad_cfg, section);
+
+	if (setting != NULL) {
+		rval = config_setting_remove(setting, ifname);
+		if (rval == CONFIG_TRUE) {
+			LLDPAD_DBG("In %s, remove %s from section %s\n", __func__, ifname, section);
+			if (config_write_file(&lldpad_cfg, cfg_file_name)) {
+				rval = cmd_success;
+			} else {
+				LLDPAD_DBG("In %s, update config failed\n", __func__);
+				rval = cmd_failed;
+			}
+		}
+	} else {
+		LLDPAD_DBG("In %s, can't find section %s\n", __func__, section);
+	}
+
+	return rval;
+}
+
 int remove_config_setting(const char *ifname, int agenttype, char *parent,
 			  char *name)
 {

--- a/include/config.h
+++ b/include/config.h
@@ -79,6 +79,7 @@ int get_cfg(const char *ifname, int agenttype, char *path, union cfg_get value, 
 int set_cfg(const char *ifname, int agenttype, char *path, union cfg_set value, int type);
 int get_config_setting(const char *ifname, int agenttype, char *path, union cfg_get value, int type);
 int set_config_setting(const char *ifname, int agenttype, char *path, union cfg_set value, int type);
+int remove_config_device(const char *ifname, int agenttype);
 int remove_config_setting(const char *ifname, int agenttype, char *parent, char *name);
 int get_config_tlvfield(const char *ifname, int agenttype, u32 tlvid, const char *field, union cfg_get value, int type);
 int get_config_tlvfield_int(const char *ifname, int agenttype, u32 tlvid, const char *field, int *value);

--- a/lldp/ports.c
+++ b/lldp/ports.c
@@ -355,6 +355,9 @@ int remove_port(const char *ifname)
 			free(agent->tx.frameout);
 
 		LIST_REMOVE(agent, entry);
+
+		remove_config_device(ifname, agent->type);
+
 		free(agent);
 	}
 


### PR DESCRIPTION
When ports are removed, there is no need to keep them in the configuration file. Otherwise, the port list could grow too large to manage. For example, if a user adds hundreds of virtual ports for testing and then removes them after the test, the configuration file would retain this information indefinitely. Removing these entries ensures the configuration file remains manageable.