### PR TITLE
Restrict CI build to read-only GitHub permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build CI
+permissions: read-all
 
 on:
   push:


### PR DESCRIPTION
This is part of the efforts to improve the total OpenSSF score.
