### PR TITLE
lldpad: do not remove config when stopping lldpad

### DIFF
--- a/config.c
+++ b/config.c
@@ -135,7 +135,7 @@ void scan_port(UNUSED void *eloop_data, UNUSED void *user_ctx)
 		}
 		next = port->next;
 		if (!found)
-			remove_port(port->ifname);
+			remove_port(port->ifname, true);
 	}
 
 	/* Walk port list looking for devices that should have been added

--- a/event_iface.c
+++ b/event_iface.c
@@ -297,7 +297,7 @@ static void event_if_decode_nlmsg(int route_type, void *data, int len)
 			if (route_type == RTM_DELLINK) {
 				LLDPAD_INFO("%s: %s: device removed!\n",
 					__func__, device_name);
-				remove_port(device_name);
+				remove_port(device_name, true);
 			}
 			break;
 		case IF_OPER_DORMANT:

--- a/lldp/ports.c
+++ b/lldp/ports.c
@@ -297,7 +297,7 @@ fail:
 	return NULL;
 }
 
-int remove_port(const char *ifname)
+int remove_port(const char *ifname, bool remove_config)
 {
 	int ifindex = get_ifidx(ifname);
 	struct port *port;    /* Pointer to port to remove */
@@ -356,7 +356,8 @@ int remove_port(const char *ifname)
 
 		LIST_REMOVE(agent, entry);
 
-		remove_config_device(ifname, agent->type);
+		if (remove_config)
+			remove_config_device(ifname, agent->type);
 
 		free(agent);
 	}

--- a/lldp/ports.h
+++ b/lldp/ports.h
@@ -97,7 +97,7 @@ extern struct port *porthead;
 extern "C" {
 #endif
 struct port *add_port(int ifindex, const char *);
-int remove_port(const char *);
+int remove_port(const char *, bool remove_config);
 #ifdef __cplusplus
 }
 #endif

--- a/lldpad.c
+++ b/lldpad.c
@@ -167,7 +167,7 @@ static void remove_all_adapters(void)
 
 	for (port = porthead; port; port = next) {
 		next = port->next;
-		remove_port(port->ifname);
+		remove_port(port->ifname, false);
 	}
 
 	return;


### PR DESCRIPTION
When lldpad is terminated by systemd or kill, the remove_all_adapters() function is called. However, this function is intended to release port resources, and the configuration file should not be destroyed. We only need to remove the port when it is explicitly deleted. Otherwise, all configurations will be lost when lldpad is stopped.