### PR TITLE
lldp_8023: Preserve MAC Merge verify_enabled setting

### DIFF
--- a/lldp_8023.c
+++ b/lldp_8023.c
@@ -686,20 +686,19 @@ static void ieee8023_rchange_add_eth_caps(struct ieee8023_data *bd,
 
 	/* If both we and the link partner support frame preemption, we
 	 * automatically turn our TX side on regardless of what the link
-	 * partner may do. Since we request verification, preemption will
+	 * partner may do. When we request verification, preemption will
 	 * only become active once the verification process succeeds
 	 * (the link partner ACKs our handshake). Using the largest interval
 	 * between verification attempts permitted by our hardware allows
 	 * the link partner a bit of wiggle room to delay enabling its pMAC
 	 * (which responds to our verification requests).
 	 */
-	if (!mm.tx_enabled || !mm.verify_enabled ||
-	    mm.verify_time != mm.max_verify_time) {
+	if (!mm.tx_enabled || mm.verify_time != mm.max_verify_time) {
 		LLDPAD_INFO("%s: initiating MM verification with a retry interval of %d ms...\n",
 			    bd->ifname, mm.max_verify_time);
 
 		err = ethtool_mm_change_tx_enabled(ud->ethtool_sk, bd->ifname,
-						   true, true,
+						   true, mm.verify_enabled,
 						   mm.max_verify_time);
 		if (err) {
 			LLDPAD_ERR("%s: Failed to enable TX preemption: %d\n",


### PR DESCRIPTION
The existing LLDP operation forcefully enables verify_enabled during MAC Merge (MM) verification whenever preemption support is advertised by the link partner. This behavior overrides the intended configuration and conflicts with IEEE 802.3br Section 99.4.3, which allows verification to be disabled.

This fix ensures that the verify_enabled configuration is preserved and remains a MAC Merge sublayer responsibility, aligning with IEEE 802.3br Tables 30-8 and 30-9.