### PR TITLE
lldp: fix small c&p mistakes

### DIFF
--- a/lldp_basman_cmds.c
+++ b/lldp_basman_cmds.c
@@ -237,7 +237,7 @@ static int _set_arg_info(struct cmd *cmd, UNUSED char *arg, char *argvalue,
 				   cmd->tlvid, argvalue))
 		return cmd_failed;
 
-	snprintf(obuf, obuf_len, "enableTx = %s\n", argvalue);
+	snprintf(obuf, obuf_len, "info = %s\n", argvalue);
 
 	somethingChangedLocal(cmd->ifname, cmd->type);
 

--- a/lldp_basman_cmds.c
+++ b/lldp_basman_cmds.c
@@ -394,5 +394,5 @@ int set_arg_ipv6(struct cmd *cmd, char *arg, char *argvalue,
 int test_arg_ipv6(struct cmd *cmd, char *arg, char *argvalue,
 		  char *obuf, int obuf_len)
 {
-	return _set_arg_ipv6(cmd, arg, argvalue, obuf, obuf_len, false);
+	return _set_arg_ipv6(cmd, arg, argvalue, obuf, obuf_len, true);
 }


### PR DESCRIPTION
Fixes two small copy&paste mistakes.

<hr>

And a related piece of information for future researching users: To change the `sysName` TLV value (for example to the FQDN), you can use `lldptool -i eth0 -T -V sysName info=myhost.example.org`. This config option is unfortunately not listed by `lldptool -i eth0 -t -V sysName -c` until you set it.